### PR TITLE
fix scramble generator for 333oh category

### DIFF
--- a/src/lib/cubeCollection.ts
+++ b/src/lib/cubeCollection.ts
@@ -24,7 +24,7 @@ export const cubeCollection: CubeCollection[] = [
     src: cube333,
   },
   {
-    event: "333oh",
+    event: "333",
     id: 3,
     name: "3x3 OH",
     src: cube333oh,

--- a/src/lib/timer/genScramble.js
+++ b/src/lib/timer/genScramble.js
@@ -1,7 +1,13 @@
 import { Scrambow } from "scrambow";
+import { cubeCollection } from "../cubeCollection";
 
 export default function genScramble(category) {
-  const scramble = new Scrambow(category);
+  const eventId = cubeCollection.find((cube) => cube.name === category);
+  if (!eventId) {
+    console.error("Evento no encontrado");
+    return "Error: Scrambler not available for this category.";
+  }
+  const scramble = new Scrambow(eventId.event);
   const newScramble = scramble.get(1);
   return newScramble[0].scramble_string;
 }

--- a/src/lib/timer/genScramble.js
+++ b/src/lib/timer/genScramble.js
@@ -4,7 +4,6 @@ import { cubeCollection } from "../cubeCollection";
 export default function genScramble(category) {
   const eventId = cubeCollection.find((cube) => cube.name === category);
   if (!eventId) {
-    console.error("Evento no encontrado");
     return "Error: Scrambler not available for this category.";
   }
   const scramble = new Scrambow(eventId.event);


### PR DESCRIPTION
**What does this PR do?**
Fix scrambles for 333 OH

**Related Issue(s)**
#140 

**Changes**
- Id "333 OH" is not supported by library, changed to just 333
- Improved a little bit error handler

**Screenshots or GIFs (if applicable)**
![image](https://github.com/bryanlundberg/NexusTimer/assets/119996547/6eeec316-58cb-482e-9439-e497dd37cdd3)

