### PR TITLE
Highlight mean time in lineal graph instead of last time.

### DIFF
--- a/src/components/charts/LineCharter.tsx
+++ b/src/components/charts/LineCharter.tsx
@@ -18,17 +18,17 @@ const chartOptions: any = {
   },
   localization: {
     priceFormatter: (time: number) => {
-      const timeT = formatTime(time)
-      console.log(time)
-      return timeT
+      const timeT = formatTime(time);
+      console.log(time);
+      return timeT;
     },
     timeFormatter: (time: number) => {
-      return time.toString()
+      return time.toString();
     },
   },
   timeScale: {
     tickMarkFormatter: (time: number) => {
-      return time.toString()
+      return time.toString();
     },
   },
   priceScale: {
@@ -53,23 +53,23 @@ export default function LineCharter({
   useEffect(() => {
     const container = chartContainerRef.current;
     if (container) {
-      container.innerHTML = ""
-      const chart = createChart(container, chartOptions)
-      const dataArray = cubeSelected ? data.cubeAll : data.global
-      const structuredData: any[] = []
+      container.innerHTML = "";
+      const chart = createChart(container, chartOptions);
+      const dataArray = cubeSelected ? data.cubeAll : data.global;
+      const structuredData: any[] = [];
       dataArray.forEach((i: Solve, index: number) => {
-        console.log({ time: index, value: i.time })
+        console.log({ time: index, value: i.time });
         structuredData.unshift({
           time: dataArray.length - index,
           value: i.time,
-        })
-      })
+        });
+      });
 
       const lineSeries = chart.addLineSeries({
         color: cubeSelected ? "#2962FF" : "#F4D03F",
         lastValueVisible: false,
         priceLineVisible: false,
-      })
+      });
 
       const getMeanTime = (data: TimeObject[]) => {
         return data.length
@@ -78,8 +78,8 @@ export default function LineCharter({
                 total + timeObject.value,
               0
             ) / data.length
-          : 0
-      }
+          : 0;
+      };
 
       const meanTimeLine: CreatePriceLineOptions = {
         price: getMeanTime(structuredData),
@@ -88,24 +88,24 @@ export default function LineCharter({
         lineStyle: 0,
         axisLabelVisible: true,
         title: "Mean Time",
-      }
+      };
 
-      lineSeries.setData(structuredData)
-      lineSeries.createPriceLine(meanTimeLine)
+      lineSeries.setData(structuredData);
+      lineSeries.createPriceLine(meanTimeLine);
 
-      chart.autoSizeActive()
-      chart.timeScale().fitContent()
+      chart.autoSizeActive();
+      chart.timeScale().fitContent();
 
       // Make chart responsive with screen resize
       new ResizeObserver((entries) => {
         if (entries.length === 0 || entries[0].target !== container) {
-          return
+          return;
         }
-        const newRect = entries[0].contentRect
-        chart.applyOptions({ height: newRect.height, width: newRect.width })
-      }).observe(container)
+        const newRect = entries[0].contentRect;
+        chart.applyOptions({ height: newRect.height, width: newRect.width });
+      }).observe(container);
     }
-  }, [data, cubeSelected])
+  }, [data, cubeSelected]);
 
-  return <div ref={chartContainerRef} className="w-full h-full"></div>
+  return <div ref={chartContainerRef} className="w-full h-full"></div>;
 }

--- a/src/components/charts/LineCharter.tsx
+++ b/src/components/charts/LineCharter.tsx
@@ -1,6 +1,6 @@
 import { Solve } from "@/interfaces/Solve";
 import formatTime from "@/lib/formatTime";
-import { createChart } from "lightweight-charts";
+import { CreatePriceLineOptions, createChart } from "lightweight-charts";
 import { useEffect, useRef } from "react";
 
 const chartOptions: any = {
@@ -18,23 +18,28 @@ const chartOptions: any = {
   },
   localization: {
     priceFormatter: (time: number) => {
-      const timeT = formatTime(time);
-      console.log(time);
-      return timeT;
+      const timeT = formatTime(time)
+      console.log(time)
+      return timeT
     },
     timeFormatter: (time: number) => {
-      return time.toString();
+      return time.toString()
     },
   },
   timeScale: {
     tickMarkFormatter: (time: number) => {
-      return time.toString();
+      return time.toString()
     },
   },
   priceScale: {
     autoScale: false,
   },
 };
+
+type TimeObject = {
+  time: number
+  value: number
+}
 
 export default function LineCharter({
   data,
@@ -48,37 +53,59 @@ export default function LineCharter({
   useEffect(() => {
     const container = chartContainerRef.current;
     if (container) {
-      container.innerHTML = "";
-      const chart = createChart(container, chartOptions);
-      const dataArray = cubeSelected ? data.cubeAll : data.global;
-      const structuredData: any[] = [];
+      container.innerHTML = ""
+      const chart = createChart(container, chartOptions)
+      const dataArray = cubeSelected ? data.cubeAll : data.global
+      const structuredData: any[] = []
       dataArray.forEach((i: Solve, index: number) => {
-        console.log({ time: index, value: i.time });
+        console.log({ time: index, value: i.time })
         structuredData.unshift({
           time: dataArray.length - index,
           value: i.time,
-        });
-      });
+        })
+      })
 
       const lineSeries = chart.addLineSeries({
         color: cubeSelected ? "#2962FF" : "#F4D03F",
-      });
+        lastValueVisible: false,
+        priceLineVisible: false,
+      })
 
-      lineSeries.setData(structuredData);
+      const getMeanTime = (data: TimeObject[]) => {
+        return data.length
+          ? data.reduce(
+              (total: number, timeObject: TimeObject) =>
+                total + timeObject.value,
+              0
+            ) / data.length
+          : 0
+      }
 
-      chart.autoSizeActive();
-      chart.timeScale().fitContent();
+      const meanTimeLine: CreatePriceLineOptions = {
+        price: getMeanTime(structuredData),
+        color: "red",
+        lineWidth: 2,
+        lineStyle: 0,
+        axisLabelVisible: true,
+        title: "Mean Time",
+      }
+
+      lineSeries.setData(structuredData)
+      lineSeries.createPriceLine(meanTimeLine)
+
+      chart.autoSizeActive()
+      chart.timeScale().fitContent()
 
       // Make chart responsive with screen resize
       new ResizeObserver((entries) => {
         if (entries.length === 0 || entries[0].target !== container) {
-          return;
+          return
         }
-        const newRect = entries[0].contentRect;
-        chart.applyOptions({ height: newRect.height, width: newRect.width });
-      }).observe(container);
+        const newRect = entries[0].contentRect
+        chart.applyOptions({ height: newRect.height, width: newRect.width })
+      }).observe(container)
     }
-  }, [data, cubeSelected]);
+  }, [data, cubeSelected])
 
-  return <div ref={chartContainerRef} className="w-full h-full"></div>;
+  return <div ref={chartContainerRef} className="w-full h-full"></div>
 }

--- a/src/components/charts/LineCharter.tsx
+++ b/src/components/charts/LineCharter.tsx
@@ -1,7 +1,9 @@
 import { Solve } from "@/interfaces/Solve";
 import formatTime from "@/lib/formatTime";
+import { useSettingsModalStore } from "@/store/SettingsModalStore";
 import { CreatePriceLineOptions, createChart } from "lightweight-charts";
 import { useEffect, useRef } from "react";
+import translation from "@/translations/global.json";
 
 const chartOptions: any = {
   layout: {
@@ -37,9 +39,9 @@ const chartOptions: any = {
 };
 
 type TimeObject = {
-  time: number
-  value: number
-}
+  time: number;
+  value: number;
+};
 
 export default function LineCharter({
   data,
@@ -48,6 +50,7 @@ export default function LineCharter({
   data: any;
   cubeSelected: boolean;
 }) {
+  const { lang } = useSettingsModalStore();
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -83,11 +86,11 @@ export default function LineCharter({
 
       const meanTimeLine: CreatePriceLineOptions = {
         price: getMeanTime(structuredData),
-        color: "red",
-        lineWidth: 2,
+        color: "#ff4d4d",
+        lineWidth: 1,
         lineStyle: 0,
         axisLabelVisible: true,
-        title: "Mean Time",
+        title: `${translation.timer["mean"][lang]}`,
       };
 
       lineSeries.setData(structuredData);
@@ -105,7 +108,7 @@ export default function LineCharter({
         chart.applyOptions({ height: newRect.height, width: newRect.width });
       }).observe(container);
     }
-  }, [data, cubeSelected]);
+  }, [data, cubeSelected, lang]);
 
   return <div ref={chartContainerRef} className="w-full h-full"></div>;
 }


### PR DESCRIPTION
**What does this PR do?**
This PR adds a mean time line to the lineal graph and removes the last time line for the same.

**Related Issue(s)**
Resolves issue #168 

**Changes**
- Finds average of the times in the displayed
- Adds a line in the graph denoted as mean time with the above average value
- Removes an existing line which showed the last time

**Screenshots or GIFs (if applicable)**
![image](https://github.com/bryanlundberg/NexusTimer/assets/54317556/6d6ecd8e-abdf-4b15-94cf-f83e0fbabeda)

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
