### PR TITLE
Font size for time display

### DIFF
--- a/src/components/solves/ModalSolve.tsx
+++ b/src/components/solves/ModalSolve.tsx
@@ -74,9 +74,14 @@ export default function ModalSolve() {
       >
         <div className="w-full h-auto text-xs border rounded-md sm:w-96 bg-neutral-200 border-neutral-800 ">
           <div className="flex items-center justify-between p-3 border-b border-neutral-400">
-            <div className="flex items-center text-lg font-bold">
-              <div>
-                <span className="text-base sm:text-sm">{formatTime(solve.time).split(".")[0]}</span><span className="text-sm sm:text-xs">.{formatTime(solve.time).split(".")[1]}</span>
+            <div className="flex items-center text-lg font-medium">
+              <div className="tracking-wider">
+                <span className="text-xl">
+                  {formatTime(solve.time).split(".")[0]}
+                </span>
+                <span className="text-sm">
+                  .{formatTime(solve.time).split(".")[1]}
+                </span>
               </div>
               <span className="text-xs text-red-500">
                 {solve.plus2 ? "+2" : null}

--- a/src/components/solves/ModalSolve.tsx
+++ b/src/components/solves/ModalSolve.tsx
@@ -76,7 +76,7 @@ export default function ModalSolve() {
           <div className="flex items-center justify-between p-3 border-b border-neutral-400">
             <div className="flex items-center text-lg font-bold">
               <div>
-                <span>{formatTime(solve.time).split(".")[0]}</span>.<span className="sm:text-2xl md:text-3xl lg:text-5xl">{formatTime(solve.time).split(".")[1]}</span>
+                <span className="text-base sm:text-sm">{formatTime(solve.time).split(".")[0]}</span><span className="text-sm sm:text-xs">.{formatTime(solve.time).split(".")[1]}</span>
               </div>
               <span className="text-xs text-red-500">
                 {solve.plus2 ? "+2" : null}

--- a/src/components/solves/ModalSolve.tsx
+++ b/src/components/solves/ModalSolve.tsx
@@ -75,7 +75,9 @@ export default function ModalSolve() {
         <div className="w-full h-auto text-xs border rounded-md sm:w-96 bg-neutral-200 border-neutral-800 ">
           <div className="flex items-center justify-between p-3 border-b border-neutral-400">
             <div className="flex items-center text-lg font-bold">
-              {formatTime(solve.time)}
+              <div>
+                <span>{formatTime(solve.time).split(".")[0]}</span>.<span className="sm:text-2xl md:text-3xl lg:text-5xl">{formatTime(solve.time).split(".")[1]}</span>
+              </div>
               <span className="text-xs text-red-500">
                 {solve.plus2 ? "+2" : null}
               </span>

--- a/src/components/solves/SingleSolveItem.tsx
+++ b/src/components/solves/SingleSolveItem.tsx
@@ -19,7 +19,7 @@ export default function SingleSolveItem({ solve }: SingleSolveItem) {
         className="relative flex items-center justify-center w-auto p-1 text-lg font-medium text-center transition duration-200 rounded-md cursor-pointer z-1 h-14 light:bg-neutral-50 light:shadow-sm light:shadow-neutral-400 light:hover:bg-neutral-100 light:text-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:shadow-sm dark:text-neutral-200"
       >
         <div>
-          <span>{formatTime(solve.time).split(".")[0]}</span>.<span className="sm:text-2xl md:text-3xl lg:text-5xl">{formatTime(solve.time).split(".")[1]}</span>
+          <span className="text-base sm:text-sm">{formatTime(solve.time).split(".")[0]}</span><span className="text-sm sm:text-xs">.{formatTime(solve.time).split(".")[1]}</span>
         </div>
         {solve.plus2 ? <span className="text-sm text-red-600">+2</span> : null}
         <div className="absolute z-20 text-xs top-1 left-1">

--- a/src/components/solves/SingleSolveItem.tsx
+++ b/src/components/solves/SingleSolveItem.tsx
@@ -18,7 +18,9 @@ export default function SingleSolveItem({ solve }: SingleSolveItem) {
         }}
         className="relative flex items-center justify-center w-auto p-1 text-lg font-medium text-center transition duration-200 rounded-md cursor-pointer z-1 h-14 light:bg-neutral-50 light:shadow-sm light:shadow-neutral-400 light:hover:bg-neutral-100 light:text-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:shadow-sm dark:text-neutral-200"
       >
-        {formatTime(solve.time)}
+        <div>
+          <span>{formatTime(solve.time).split(".")[0]}</span>.<span className="sm:text-2xl md:text-3xl lg:text-5xl">{formatTime(solve.time).split(".")[1]}</span>
+        </div>
         {solve.plus2 ? <span className="text-sm text-red-600">+2</span> : null}
         <div className="absolute z-20 text-xs top-1 left-1">
           {formatDate(solve.endTime).slice(0, 5)}

--- a/src/components/solves/SingleSolveItem.tsx
+++ b/src/components/solves/SingleSolveItem.tsx
@@ -16,10 +16,15 @@ export default function SingleSolveItem({ solve }: SingleSolveItem) {
           setSolve(solve);
           setStatus(true);
         }}
-        className="relative flex items-center justify-center w-auto p-1 text-lg font-medium text-center transition duration-200 rounded-md cursor-pointer z-1 h-14 light:bg-neutral-50 light:shadow-sm light:shadow-neutral-400 light:hover:bg-neutral-100 light:text-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:shadow-sm dark:text-neutral-200"
+        className="relative flex items-center justify-center w-auto gap-1 p-1 text-lg font-medium text-center transition duration-200 rounded-md cursor-pointer z-1 h-14 light:bg-neutral-50 light:shadow-sm light:shadow-neutral-400 light:hover:bg-neutral-100 light:text-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:shadow-sm dark:text-neutral-200"
       >
-        <div>
-          <span className="text-base sm:text-sm">{formatTime(solve.time).split(".")[0]}</span><span className="text-sm sm:text-xs">.{formatTime(solve.time).split(".")[1]}</span>
+        <div className="tracking-wider">
+          <span className="text-md">
+            {formatTime(solve.time).split(".")[0]}
+          </span>
+          <span className="text-sm">
+            .{formatTime(solve.time).split(".")[1]}
+          </span>
         </div>
         {solve.plus2 ? <span className="text-sm text-red-600">+2</span> : null}
         <div className="absolute z-20 text-xs top-1 left-1">

--- a/src/components/timer/Timer.tsx
+++ b/src/components/timer/Timer.tsx
@@ -52,7 +52,7 @@ export default function Timer() {
               </span>
             ) : (
               <div>
-                <span>{formatTime(solvingTime).split(".")[0]}</span>.<span className="sm:text-2xl md:text-3xl lg:text-5xl">{formatTime(solvingTime).split(".")[1]}</span>
+                <span className="sm:text-5xl md:text-6xl lg:text-7xl">{formatTime(solvingTime).split(".")[0]}</span><span className="sm:text-2xl md:text-3xl lg:text-5xl">.{formatTime(solvingTime).split(".")[1]}</span>
               </div>
             )}
           </div>

--- a/src/components/timer/Timer.tsx
+++ b/src/components/timer/Timer.tsx
@@ -43,16 +43,19 @@ export default function Timer() {
         className="flex flex-col items-center justify-center grow"
       >
         {selectedCube && (
-          <div
-            className={`text-6xl sm:text-7xl md:text-8xl lg:text-9xl font-mono select-none ${timerStatusClasses[timerStatus]}`}
-          >
+          <div className={`${timerStatusClasses[timerStatus]}`}>
             {hideWhileSolving && isSolving ? (
               <span className="sm:text-5xl md:text-6xl lg:text-7xl">
                 {translation.timer["solving"][lang]}
               </span>
             ) : (
-              <div>
-                <span className="sm:text-5xl md:text-6xl lg:text-7xl">{formatTime(solvingTime).split(".")[0]}</span><span className="sm:text-2xl md:text-3xl lg:text-5xl">.{formatTime(solvingTime).split(".")[1]}</span>
+              <div className="font-mono">
+                <span className="text-6xl sm:text-7xl md:text-8xl lg:text-9xl">
+                  {formatTime(solvingTime).split(".")[0]}
+                </span>
+                <span className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl">
+                  .{formatTime(solvingTime).split(".")[1]}
+                </span>
               </div>
             )}
           </div>

--- a/src/components/timer/Timer.tsx
+++ b/src/components/timer/Timer.tsx
@@ -51,7 +51,9 @@ export default function Timer() {
                 {translation.timer["solving"][lang]}
               </span>
             ) : (
-              formatTime(solvingTime)
+              <div>
+                <span>{formatTime(solvingTime).split(".")[0]}</span>.<span className="sm:text-2xl md:text-3xl lg:text-5xl">{formatTime(solvingTime).split(".")[1]}</span>
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
Changed font size for second half of time display by using .split(".") and wrapping in separate span tags


**What does this PR do?**
Minor visual enhancement where the solve time's decimal component is a smaller font size.

**Related Issue(s)**
None

**Changes**
Used the split function to separate the time string and rendered each part in different span tags with a different font size. This is applied on 3 different places, the solve modal, the grid view and the main Timer.tsx file. 

**Additional Comments**
I haven't thoroughly tested this yet so would like some feedback and expect some adjustments.

**By submitting this PR, I confirm that:**
- [*] I have reviewed my code and believe it is ready for merging.
- [*] I understand that this PR may be subject to review and changes.
- [*] I agree to abide by the code of conduct and contributing guidelines of this project.
