### PR TITLE
fix: sync cubes after import

### DIFF
--- a/src/components/menu-settings/DataImportExport.tsx
+++ b/src/components/menu-settings/DataImportExport.tsx
@@ -1,19 +1,19 @@
 import exportDataToFile from "@/lib/exportDataToFile";
-import translation from "@/translations/global.json";
 import { Button } from "@/components/button";
-import { Language } from "@/interfaces/types/Language";
 import { useRef } from "react";
 import importDataFromFile from "@/lib/importDataFromFile";
 import Import from "@/icons/Import";
 import Export from "@/icons/Export";
+import translation from "@/translations/global.json";
+import { useSettingsModalStore } from "@/store/SettingsModalStore";
+import { useTimerStore } from "@/store/timerStore";
+import { useRouter } from "next/navigation";
 
-interface DataImportExport {
-  lang: Language;
-}
-
-export function DataImportExport({ lang }: DataImportExport) {
+export function DataImportExport() {
   const dataInputRef = useRef<HTMLInputElement>(null);
-
+  const { lang } = useSettingsModalStore();
+  const { setSelectedCube } = useTimerStore();
+  const router = useRouter();
   return (
     <div className="light flex justify-center gap-2">
       <input
@@ -21,7 +21,11 @@ export function DataImportExport({ lang }: DataImportExport) {
         accept=".txt"
         ref={dataInputRef}
         className="hidden"
-        onChange={importDataFromFile}
+        onChange={(e) => {
+          importDataFromFile(e);
+          router.push("/cubes");
+          setSelectedCube(null);
+        }}
       />
       <Button
         className="font-normal transition duration-400"

--- a/src/components/menu-settings/Menu.tsx
+++ b/src/components/menu-settings/Menu.tsx
@@ -134,7 +134,7 @@ export default function MenuSettings() {
             icon={<Folder />}
             title={translation.settings["data"][lang]}
           >
-            <DataImportExport lang={lang} />
+            <DataImportExport />
           </MenuSection>
           <MenuSection
             icon={<Shield />}


### PR DESCRIPTION
**What does this PR do?**
Update the available new cube list after each import.

**Related Issue(s)**
#192 

**Changes**
Redirect to the /cubes page during import
Otimize language inheritance 

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
