### PR TITLE
disabled buttons when cube is not selected

### DIFF
--- a/src/app/solves/page.tsx
+++ b/src/app/solves/page.tsx
@@ -14,6 +14,7 @@ import { ButtonsSection } from "@/components/solves/ButtonsSection";
 import { SolvesArea } from "@/components/solves/SolvesArea";
 import useSolvesPage from "@/hooks/useSolvesPage";
 import { InputText } from "@/components/input-text/index";
+import { useTimerStore } from "@/store/timerStore";
 
 export default function SolvesPage() {
   const {
@@ -23,8 +24,8 @@ export default function SolvesPage() {
     handleTrashAll,
     handleSearch,
     displaySolves,
-    selectedCube
   } = useSolvesPage();
+  const {selectedCube } = useTimerStore();
   const { lang } = useSettingsModalStore();
 
   return (
@@ -50,7 +51,7 @@ export default function SolvesPage() {
                 onClick={() => handleMoveAll()}
                 icon={<MoveAll />}
                 label={translation.inputs["move-all"][lang]}
-                isDisabled={true ? selectedCube === null : false}
+                isDisabled={selectedCube === null || selectedCube.solves.session.length === 0}
               />
               <Button
                 onClick={() => handleTrashAll()}
@@ -60,7 +61,7 @@ export default function SolvesPage() {
                   </div>
                 }
                 label={translation.inputs["trash-all"][lang]}
-                isDisabled={true ? selectedCube === null : false}
+                isDisabled={selectedCube === null || selectedCube.solves.session.length === 0}
               />
             </ButtonsSection>
           </div>

--- a/src/app/solves/page.tsx
+++ b/src/app/solves/page.tsx
@@ -23,6 +23,7 @@ export default function SolvesPage() {
     handleTrashAll,
     handleSearch,
     displaySolves,
+    selectedCube
   } = useSolvesPage();
   const { lang } = useSettingsModalStore();
 
@@ -49,6 +50,7 @@ export default function SolvesPage() {
                 onClick={() => handleMoveAll()}
                 icon={<MoveAll />}
                 label={translation.inputs["move-all"][lang]}
+                isDisabled={true ? selectedCube === null : false}
               />
               <Button
                 onClick={() => handleTrashAll()}
@@ -58,6 +60,7 @@ export default function SolvesPage() {
                   </div>
                 }
                 label={translation.inputs["trash-all"][lang]}
+                isDisabled={true ? selectedCube === null : false}
               />
             </ButtonsSection>
           </div>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -7,6 +7,7 @@ interface Button {
   label: string;
   onClick: () => void;
   minimalistic?: boolean;
+  isDisabled?: boolean;
 }
 
 export default function Button({
@@ -15,10 +16,11 @@ export default function Button({
   label,
   onClick,
   minimalistic = true,
+  isDisabled
 }: Button) {
   return (
     <>
-      <ButtonContainer className={className} handleClick={onClick}>
+      <ButtonContainer className={className} handleClick={onClick} isDisabled={isDisabled}>
         <ButtonContent icon={icon} label={label} minimalistic={minimalistic} />
       </ButtonContainer>
     </>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -16,7 +16,7 @@ export default function Button({
   label,
   onClick,
   minimalistic = true,
-  isDisabled
+  isDisabled = false 
 }: Button) {
   return (
     <>

--- a/src/components/button/ButtonContainer.tsx
+++ b/src/components/button/ButtonContainer.tsx
@@ -2,19 +2,22 @@ interface ButtonContainer {
   children: React.ReactNode;
   className?: string;
   handleClick: () => void;
+  isDisabled?: boolean;
 }
 
 export function ButtonContainer({
   className,
   children,
   handleClick,
+  isDisabled
 }: ButtonContainer) {
   return (
     <>
       <button
         type="button"
         className={`min-h-9 px-3 transition duration-200 rounded-md border font-medium justify-center align-middle light:hover:bg-neutral-200 light:text-neutral-950 light:border-neutral-200 dark:hover:bg-zinc-700 dark:hover:border-zinc-500 dark:border-zinc-800 text-md disabled:bg-zinc-900 ${className}`}
-        onClick={handleClick}
+        onClick={!isDisabled ? handleClick : undefined}
+        style={{cursor:isDisabled ? 'not-allowed' : 'initial'}}
       >
         {children}
       </button>

--- a/src/components/button/ButtonContainer.tsx
+++ b/src/components/button/ButtonContainer.tsx
@@ -9,14 +9,14 @@ export function ButtonContainer({
   className,
   children,
   handleClick,
-  isDisabled
+  isDisabled,
 }: ButtonContainer) {
   return (
     <>
       <button
         type="button"
-        className={`min-h-9 px-3 transition duration-200 rounded-md border font-medium justify-center align-middle light:hover:bg-neutral-200 light:text-neutral-950 light:border-neutral-200 dark:hover:bg-zinc-700 dark:hover:border-zinc-500 dark:border-zinc-800 text-md disabled:bg-zinc-900 ${className} disabled:cursor-not-allowed`}
-        onClick={!isDisabled ? handleClick : undefined}
+        className={`min-h-9 px-3 transition duration-200 rounded-md border font-medium justify-center align-middle light:hover:bg-neutral-200 light:hover:border-neutral-400 light:text-neutral-950 light:border-neutral-200 dark:hover:bg-zinc-700 dark:hover:border-zinc-500 dark:border-zinc-800 text-md disabled:bg-zinc-900 dark:disabled:border-zinc-500 dark:disabled:bg-zinc-700 light:disabled:bg-neutral-200 light:disabled:border-neutral-300 ${className} disabled:cursor-normal`}
+        onClick={handleClick}
         disabled={isDisabled}
       >
         {children}

--- a/src/components/button/ButtonContainer.tsx
+++ b/src/components/button/ButtonContainer.tsx
@@ -15,9 +15,9 @@ export function ButtonContainer({
     <>
       <button
         type="button"
-        className={`min-h-9 px-3 transition duration-200 rounded-md border font-medium justify-center align-middle light:hover:bg-neutral-200 light:text-neutral-950 light:border-neutral-200 dark:hover:bg-zinc-700 dark:hover:border-zinc-500 dark:border-zinc-800 text-md disabled:bg-zinc-900 ${className}`}
+        className={`min-h-9 px-3 transition duration-200 rounded-md border font-medium justify-center align-middle light:hover:bg-neutral-200 light:text-neutral-950 light:border-neutral-200 dark:hover:bg-zinc-700 dark:hover:border-zinc-500 dark:border-zinc-800 text-md disabled:bg-zinc-900 ${className} disabled:cursor-not-allowed`}
         onClick={!isDisabled ? handleClick : undefined}
-        style={{cursor:isDisabled ? 'not-allowed' : 'initial'}}
+        disabled={isDisabled}
       >
         {children}
       </button>

--- a/src/hooks/useSolvesPage.ts
+++ b/src/hooks/useSolvesPage.ts
@@ -96,5 +96,6 @@ export default function useSolvesPage() {
     handleTrashAll,
     handleSearch,
     displaySolves,
+    selectedCube
   };
 }

--- a/src/hooks/useSolvesPage.ts
+++ b/src/hooks/useSolvesPage.ts
@@ -96,6 +96,5 @@ export default function useSolvesPage() {
     handleTrashAll,
     handleSearch,
     displaySolves,
-    selectedCube
   };
 }


### PR DESCRIPTION
**What does this PR do?**
I have addressed the issue #222 

**Changes**
Disabled the button when no cube is selected from the select list in the solves page.

**Screenshots or GIFs (if applicable)**
If your PR includes visual changes, provide screenshots or GIFs to demonstrate the ![btn_fix](https://github.com/bryanlundberg/NexusTimer/assets/78807238/6e6141dd-76f0-4499-8acd-6cf4123c3fcb).

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
