### PR TITLE
fix: detect release to start timer on tap

### DIFF
--- a/src/components/timer/TimerWidgets.tsx
+++ b/src/components/timer/TimerWidgets.tsx
@@ -10,7 +10,7 @@ export default function TimerWidgets() {
   const { isSolving, timerStatus } = useTimerStore();
   const { lang, settings } = useSettingsModalStore();
   const { global, session } = useTimerStatistics();
-  if (isSolving || timerStatus !== "IDLE") return null;
+
   return (
     <>
       <div className="flex flex-col gap-1" id="touch">
@@ -25,7 +25,11 @@ export default function TimerWidgets() {
             </div>
           </div>
         ) : null}
-        <div className="flex items-center justify-between w-full h-20 text-xs sm:h-20 md:h-24 lg:h-32 md:text-sm">
+        <div
+          className={`items-center justify-between w-full h-20 text-xs sm:h-20 md:h-24 lg:h-32 md:text-sm ${
+            isSolving || timerStatus !== "IDLE" ? "hidden" : "flex"
+          }`}
+        >
           <OverviewPanel />
           <ScramblePanel />
           <StatisticsPanel />


### PR DESCRIPTION
**What does this PR do?**
Fix detect release to start timer on tap, hot fix for mobile users.

**Related Issue(s)**
#229 

**Changes**
Due to the removal of the UI component when it was ready, the timer lost the reference for the stop-holding event. Instead, it was changed to be hidden with CSS.


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
