### PR TITLE
fix: order solves in chart by date

### DIFF
--- a/src/components/timer/ManualMode.tsx
+++ b/src/components/timer/ManualMode.tsx
@@ -50,7 +50,7 @@ export default function ManualMode() {
           const newSolve: Solve = {
             id: genId(),
             startTime: now - msTime,
-            endTime: now + msTime,
+            endTime: now,
             scramble: scramble,
             bookmark: false,
             time: msTime,

--- a/src/lib/getSolvesMetrics.ts
+++ b/src/lib/getSolvesMetrics.ts
@@ -1,7 +1,6 @@
 import { Solve } from "@/interfaces/Solve";
 import loadCubes from "./loadCubes";
 import { Categories } from "@/interfaces/Categories";
-import { sort } from "fast-sort";
 
 export default function getSolvesMetrics(
   category: Categories,
@@ -33,17 +32,17 @@ export default function getSolvesMetrics(
     cube.solves.session.map((i) => result.session.push(i));
   }
 
-  sort(result.global).asc((u) => u.endTime);
-  sort(result.session).asc((u) => u.endTime);
-
   const targetCube = cubesDB.find((cube) => cube.name === cubeName);
   if (targetCube) {
     targetCube.solves.all.map((i) => result.cubeAll.push(i));
     targetCube.solves.session.map((i) => result.cubeAll.push(i));
     targetCube.solves.session.map((i) => result.cubeSession.push(i));
-    sort(result.cubeAll).asc((u) => u.endTime);
-    sort(result.cubeSession).asc((u) => u.endTime);
   }
+
+  result.global.sort((a, b) => b.endTime - a.endTime);
+  result.session.sort((a, b) => b.endTime - a.endTime);
+  result.cubeAll.sort((a, b) => b.endTime - a.endTime);
+  result.cubeSession.sort((a, b) => b.endTime - a.endTime);
 
   return result;
 }


### PR DESCRIPTION
**What does this PR do?**
Fix order solves in chart by date

before:
![image](https://github.com/bryanlundberg/NexusTimer/assets/119996547/e7f4b902-8c04-4d81-9648-c978b35e05f5)


after:
![image](https://github.com/bryanlundberg/NexusTimer/assets/119996547/126973fb-9473-4385-80a5-6304de4e8d6e)

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
