### PR TITLE
fix: zoom and scrolling statistics-chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "fast-sort": "3.4.0",
         "framer-motion": "^10.17.4",
         "idb-wrapper": "^1.7.2",
-        "lightweight-charts": "^4.1.0",
+        "lightweight-charts": "^4.1.4",
         "next": "14.1.1",
         "papaparse": "^5.4.1",
         "postcss": "8.4.31",
@@ -3120,9 +3120,9 @@
       }
     },
     "node_modules/lightweight-charts": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.1.0.tgz",
-      "integrity": "sha512-O7RPoRLPPmwRNOTmBq1ne5eKgjdVZocd2TE77JCfaVJEwS+0meN9UwMKGNGiiRQBb2UkuhyBSiX7XrErBuL+CQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.1.4.tgz",
+      "integrity": "sha512-jsQOK27a3wiw/Db3Eoo3VX93LGovXA/sOWHVEiEosGOOGtxSSuIWTYVebjRKGK0SWkkUwI8AHQ4j7HZSKm7fxA==",
       "dependencies": {
         "fancy-canvas": "2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fast-sort": "3.4.0",
     "framer-motion": "^10.17.4",
     "idb-wrapper": "^1.7.2",
-    "lightweight-charts": "^4.1.0",
+    "lightweight-charts": "^4.1.4",
     "next": "14.1.1",
     "papaparse": "^5.4.1",
     "postcss": "8.4.31",

--- a/src/components/charts/LineCharter.tsx
+++ b/src/components/charts/LineCharter.tsx
@@ -1,7 +1,12 @@
 import { Solve } from "@/interfaces/Solve";
 import formatTime from "@/lib/formatTime";
 import { useSettingsModalStore } from "@/store/SettingsModalStore";
-import { CreatePriceLineOptions, createChart } from "lightweight-charts";
+import {
+  ChartOptions,
+  CreatePriceLineOptions,
+  DeepPartial,
+  createChart,
+} from "lightweight-charts";
 import { useEffect, useRef } from "react";
 import translation from "@/translations/global.json";
 import getBestTime from "@/lib/getBestTime";
@@ -29,12 +34,19 @@ export default function LineCharter({
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    const chartOptions: any = {
+    const chartOptions: DeepPartial<ChartOptions> = {
+      watermark: {
+        visible: true,
+        fontSize: 24,
+        horzAlign: "center",
+        vertAlign: "center",
+        color: "rgba(120,120,120, 0.1)",
+        text: "nexustimer.pro",
+      },
       layout: {
         textColor:
           settings.theme.background.color === "dark" ? "white" : "gray",
         background: {
-          type: "solid",
           color:
             settings.theme.background.color === "dark" ? "#09090B" : "#F5F5F5",
         },
@@ -68,6 +80,15 @@ export default function LineCharter({
         },
         fixRightEdge: true,
         fixLeftEdge: true,
+        allowBoldLabels: false,
+      },
+      kineticScroll: {
+        mouse: true,
+      },
+      handleScale: {
+        axisPressedMouseMove: {
+          price: false,
+        },
       },
     };
     const container = chartContainerRef.current;


### PR DESCRIPTION
**What does this PR do?**
Correct the error: when you zoomed in excessively, you started to see the scale in negative numbers. This was fixed by disabling auto-scaling on the Y-axis. Additionally, the kinetic effect was added for the desktop version when scrolling with the graph, disabled bold labels, added watermark.

**Related Issue(s)**
#201 

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
