### PR TITLE
fix: prevent UI blocking during 333 solver initialization

### DIFF
--- a/src/worker/solver333Worker.js
+++ b/src/worker/solver333Worker.js
@@ -1,0 +1,11 @@
+import cubeSolver from "cube-solver";
+
+self.onmessage = async (event) => {
+  const { type } = event.data;
+  try {
+    await cubeSolver.initialize(type);
+    self.postMessage({ success: true });
+  } catch (error) {
+    self.postMessage({ success: false, error: error.message });
+  }
+};


### PR DESCRIPTION
**What does this PR do?**
the initialization of the 333 cross & xcross solver was blocking the UI thread. By offloading the initialization process to a web worker, we ensure that the UI remains responsive during this operation.

issue: (interface respond until finish initializing process)

https://github.com/bryanlundberg/NexusTimer/assets/119996547/5754416e-fbc2-4f11-a170-4e1ea10fac9b


after: (interface keeps responsive while initializing process) [simulate 5 sec delay loading]

https://github.com/bryanlundberg/NexusTimer/assets/119996547/cb0da77a-c2ad-45a4-9d72-3289ac94b18f


**Changes**
- Implemented a web worker to handle the initialization of the 333 solver.
- Modified the hook to interact with the web worker and update the initializing state based on the worker's messages.


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
