### PR TITLE
style: remove the visual reference "active" on closed modal

### DIFF
--- a/src/components/solves/SolvesArea.tsx
+++ b/src/components/solves/SolvesArea.tsx
@@ -69,7 +69,7 @@ export function SolvesArea({ displaySolves, currentTab }: SolvesArea) {
             light:bg-neutral-100 light:shadow-sm light:shadow-neutral-400 light:hover:bg-neutral-200 light:text-zinc-800 
             dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:shadow-sm dark:text-neutral-200 
             ${
-              displaySolves[index] === solve && solve !== null
+              displaySolves[index] === solve && showOptions
                 ? "border border-neutral-600"
                 : "border-none"
             }`}


### PR DESCRIPTION
**What does this PR do?**
remove the border on clicked item, after modal closes

**Screenshots or GIFs (if applicable)**
Before:

https://github.com/bryanlundberg/NexusTimer/assets/119996547/489c5faa-b7ec-4d70-91b8-e5568a038cc9

after:

https://github.com/bryanlundberg/NexusTimer/assets/119996547/6cc4bc93-0801-4069-9ce3-0b1159736f1a





**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
