### PR TITLE
Cube name validation error when editing Cube, fixed.

### DIFF
--- a/src/components/dialogs/dialog-edit-collection/dialog-edit-collection.tsx
+++ b/src/components/dialogs/dialog-edit-collection/dialog-edit-collection.tsx
@@ -41,7 +41,6 @@ export default function DialogEditCollection() {
   });
   const handleSubmitEditCubeCollection = async () => {
     try {
-      console.log('This is cube.name: ', cube?.name)
       // verify if its repeated the name
       if (cube?.name !== form.name && cubes?.some((e) => e.name === form.name)) {
         setError((prev) => ({

--- a/src/components/dialogs/dialog-edit-collection/dialog-edit-collection.tsx
+++ b/src/components/dialogs/dialog-edit-collection/dialog-edit-collection.tsx
@@ -41,8 +41,9 @@ export default function DialogEditCollection() {
   });
   const handleSubmitEditCubeCollection = async () => {
     try {
+      console.log('This is cube.name: ', cube?.name)
       // verify if its repeated the name
-      if (cubes?.some((e) => e.name === form.name)) {
+      if (cube?.name !== form.name && cubes?.some((e) => e.name === form.name)) {
         setError((prev) => ({
           ...prev,
           status: true,


### PR DESCRIPTION
**What does this PR do?**
Se agregó una condición mas al if que valida el nuevo nombre ingresado via edit.
Si el nombre ingresado via edit es igual al nombre actual del cubo, entonces sabemos que el nombre no esta presente en la lista de cubos. (no hace falta ni revisar la lista)

**Related Issue(s)**
https://github.com/bryanlundberg/NexusTimer/issues/343

**Changes**
- Bug Fix: En https://www.nexustimer.pro/cubes, al editar un cubo, al cambiar el tipo de cubo, obliga a cambiar el nombre del cubo.

**By submitting this PR, I confirm that:**
- [x ] I have reviewed my code and believe it is ready for merging.
- [x ] I understand that this PR may be subject to review and changes.
- [x ] I agree to abide by the code of conduct and contributing guidelines of this project.
