### PR TITLE
style: adjust hover area for tooltip

### DIFF
--- a/src/components/navbar/NavItem.tsx
+++ b/src/components/navbar/NavItem.tsx
@@ -31,7 +31,7 @@ export function NavItem({ path, icon, toolTipMessage }: NavItem) {
                   } transition duration-300 py-2 flex flex-col justify-center items-center font-medium  `
                 )}
               >
-                <InteractiveIcon icon={icon} animation={false} />
+                {icon}
               </Link>
             </li>
           </TooltipTrigger>

--- a/src/components/navbar/NavItem.tsx
+++ b/src/components/navbar/NavItem.tsx
@@ -1,6 +1,5 @@
 import { Link, usePathname } from "@/i18n/routing";
 import { twMerge } from "tailwind-merge";
-import { InteractiveIcon } from "../timer/InteractiveIcon";
 import {
   Tooltip,
   TooltipContent,

--- a/src/components/navbar/NavItem.tsx
+++ b/src/components/navbar/NavItem.tsx
@@ -1,34 +1,45 @@
 import { Link, usePathname } from "@/i18n/routing";
 import { twMerge } from "tailwind-merge";
 import { InteractiveIcon } from "../timer/InteractiveIcon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
 
 interface NavItem {
   path: string;
   icon: React.ReactNode;
-  toolTipMessage:string;
+  toolTipMessage: string;
 }
 
-export function NavItem({ path, icon , toolTipMessage}: NavItem) {
+export function NavItem({ path, icon, toolTipMessage }: NavItem) {
   const pathname = usePathname();
   return (
     <>
-      <li className="grow first:rounded-s-md last:rounded-e-md overflow-hidden">
-        <Link
-          href={path}
-          data-testid={"nav" + path}
-          className={twMerge(
-            `${
-              pathname === path ? "bg-secondary" : ""
-            } transition duration-300 py-2 flex flex-col justify-center items-center font-medium  `
-          )}
-        >
-          <InteractiveIcon
-              icon={icon}
-              animation={false}
-              message={toolTipMessage}
-            />
-        </Link>
-      </li>
+      <TooltipProvider delayDuration={250}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <li className="grow first:rounded-s-md last:rounded-e-md overflow-hidden">
+              <Link
+                href={path}
+                data-testid={"nav" + path}
+                className={twMerge(
+                  `${
+                    pathname === path ? "bg-secondary" : ""
+                  } transition duration-300 py-2 flex flex-col justify-center items-center font-medium  `
+                )}
+              >
+                <InteractiveIcon icon={icon} animation={false} />
+              </Link>
+            </li>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{toolTipMessage}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </>
   );
 }

--- a/src/components/timer/InteractiveIcon.tsx
+++ b/src/components/timer/InteractiveIcon.tsx
@@ -1,41 +1,21 @@
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-
 interface InteractiveIconProps extends React.HTMLAttributes<HTMLDivElement> {
   icon: React.ReactNode;
   animation?: boolean;
-  message?: string;
 }
 
 export function InteractiveIcon({
   icon,
   animation = false,
-  message,
   ...props
 }: InteractiveIconProps) {
   return (
-    <TooltipProvider delayDuration={250}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            {...props}
-            className={`light:text-neutral-800 light:hover:text-neutral-600 dark:text-neutral-100 dark:hover:text-neutral-200 hover:cursor-pointer duration-300 transition ${
-              animation ? "hover:rotate-45" : ""
-            }`}
-          >
-            {icon}
-          </div>
-        </TooltipTrigger>
-        {message && (
-          <TooltipContent>
-            <p>{message}</p>
-          </TooltipContent>
-        )}
-      </Tooltip>
-    </TooltipProvider>
+    <div
+      {...props}
+      className={`light:text-neutral-800 light:hover:text-neutral-600 dark:text-neutral-100 dark:hover:text-neutral-200 hover:cursor-pointer duration-300 transition ${
+        animation ? "hover:rotate-45" : ""
+      }`}
+    >
+      {icon}
+    </div>
   );
 }

--- a/src/components/timer/InteractiveIcon.tsx
+++ b/src/components/timer/InteractiveIcon.tsx
@@ -1,21 +1,41 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 interface InteractiveIconProps extends React.HTMLAttributes<HTMLDivElement> {
   icon: React.ReactNode;
   animation?: boolean;
+  message?: string;
 }
 
 export function InteractiveIcon({
   icon,
   animation = false,
+  message,
   ...props
 }: InteractiveIconProps) {
   return (
-    <div
-      {...props}
-      className={`light:text-neutral-800 light:hover:text-neutral-600 dark:text-neutral-100 dark:hover:text-neutral-200 hover:cursor-pointer duration-300 transition ${
-        animation ? "hover:rotate-45" : ""
-      }`}
-    >
-      {icon}
-    </div>
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            {...props}
+            className={`light:text-neutral-800 light:hover:text-neutral-600 dark:text-neutral-100 dark:hover:text-neutral-200 hover:cursor-pointer duration-300 transition ${
+              animation ? "hover:rotate-45" : ""
+            }`}
+          >
+            {icon}
+          </div>
+        </TooltipTrigger>
+        {message && (
+          <TooltipContent>
+            <p>{message}</p>
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
**What does this PR do?**
Adjusted the hover area for displaying the tooltip. Previously, the tooltip was only triggered when hovering over the icon. Now, it activates when hovering over the entire button area, enhancing usability and interaction.

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
