### PR TITLE
feat: Integrate `isOpenDrawerNewCollection` state into timerStore

### DIFF
--- a/src/components/MainCubeSelector.tsx
+++ b/src/components/MainCubeSelector.tsx
@@ -18,8 +18,14 @@ import { Cube } from "@/interfaces/Cube";
 
 export default function MainCubeSelector() {
   const t = useTranslations("Index");
-  const { cubes, setSelectedCube, setNewScramble, setLastSolve, selectedCube } =
-    useTimerStore();
+  const {
+    cubes,
+    setSelectedCube,
+    setNewScramble,
+    setLastSolve,
+    selectedCube,
+    setIsOpenDrawerNewCollection,
+  } = useTimerStore();
   const handleChangeValue = (e: any) => {
     const choseCube = cubes?.find((cube) => cube.id === e);
     if (!choseCube) return;
@@ -76,7 +82,10 @@ export default function MainCubeSelector() {
                 .map((cube) => {
                   return <SelectCubeItemWidthImage cube={cube} key={cube.id} />;
                 })}
-            <Link href={"/cubes"} className="">
+            <Link
+              href={"/cubes"}
+              onClick={() => setIsOpenDrawerNewCollection(true)}
+            >
               <Button variant={"outline"} className="w-full">
                 <div className="flex items-center justify-center gap-1">
                   <PlusIcon />

--- a/src/components/navigation/buttons/button-create-collection.tsx
+++ b/src/components/navigation/buttons/button-create-collection.tsx
@@ -1,13 +1,12 @@
 import { Drawer, DrawerTrigger } from "@/components/ui/drawer";
 import DrawerCreateCollection from "@/components/drawners/drawner-create-collection/drawner-create-collection";
-import { useState } from "react";
 import { PlusIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
+import { useTimerStore } from "@/store/timerStore";
 
 export default function ButtonCreateCollection() {
-  const [isOpenDrawerNewCollection, setIsOpenDrawerNewCollection] =
-    useState(false);
+  const { isOpenDrawerNewCollection, setIsOpenDrawerNewCollection } = useTimerStore();
   const t = useTranslations("Index");
   return (
     <>

--- a/src/store/timerStore.ts
+++ b/src/store/timerStore.ts
@@ -23,6 +23,7 @@ type TimerStore = {
   hint: CrossSolutions | null;
   timerStatistics: DisplayTimerStatistics;
   timerMode: TimerMode.NORMAL | TimerMode.STACKMAT;
+  isOpenDrawerNewCollection: boolean;
   setNewScramble: (cube: Cube | null) => void;
   setCubes: (cubesDB: Cube[]) => void;
   setSelectedCube: (cube: Cube | null) => void;
@@ -36,6 +37,7 @@ type TimerStore = {
   setCustomScramble: (scramble: string) => void;
   setTimerStatistics: () => void;
   setTimerMode: (mode: TimerMode.NORMAL | TimerMode.STACKMAT) => void;
+  setIsOpenDrawerNewCollection: (status: boolean) => void;
 };
 
 export const useTimerStore = create<TimerStore>((set) => ({
@@ -56,6 +58,7 @@ export const useTimerStore = create<TimerStore>((set) => ({
     cubeSession: defaultTimerStatistics,
   },
   timerMode: TimerMode.NORMAL,
+  isOpenDrawerNewCollection: false,
   setNewScramble: (cube: Cube | null) => {
     set({ scramble: cube ? genScramble(cube.category) : null });
   },
@@ -121,5 +124,8 @@ export const useTimerStore = create<TimerStore>((set) => ({
   },
   setTimerMode: (mode: TimerMode.NORMAL | TimerMode.STACKMAT) => {
     set({ timerMode: mode });
+  },
+  setIsOpenDrawerNewCollection: (status: boolean) => {
+    set({ isOpenDrawerNewCollection: status });
   },
 }));


### PR DESCRIPTION
Moved isOpenDrawerNewCollection state management from local component state to global timerStore. Updated ButtonCreateCollection and MainCubeSelector components to utilize the global store for consistent state handling.


**Screenshots or GIFs (if applicable)**
![c5b9f72cc3c5f68e100b5a5e70f5ee1f](https://github.com/user-attachments/assets/e19addc4-8af8-4719-b159-6cbddf81b6d5)



**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
