### PR TITLE
feat: add support for customizable theme colors

### DIFF
--- a/src/app/settings/options/page.tsx
+++ b/src/app/settings/options/page.tsx
@@ -17,6 +17,8 @@ import MenuSelectLanguage from "@/components/menu-settings/MenuSelectLanguage";
 import CustomTheme from "@/components/menu-settings/CustomTheme";
 import MenuSelectDefaultStartCube from "@/components/menu-settings/MenuSelectDefaultStartCube";
 import AccountHeader from "@/components/account/account-header/account-header";
+import { Separator } from "@/components/ui/separator";
+import MenuSelectColor from "@/components/menu-settings/MenuSelectColor";
 
 export default function Page() {
   const { settings } = useSettingsModalStore();
@@ -28,6 +30,8 @@ export default function Page() {
           <AccountHeader back="/settings" label={t("SettingsPage.options")} />
 
           <MenuSelectLanguage />
+
+          <Separator className="my-5" />
 
           <MenuSection
             id="timer"
@@ -51,6 +55,8 @@ export default function Page() {
               label={t("Settings-menu.manual-mode")}
             />
           </MenuSection>
+
+          <Separator className="my-5" />
 
           <MenuSection
             id="features"
@@ -79,6 +85,8 @@ export default function Page() {
             />
           </MenuSection>
 
+          <Separator className="my-5" />
+
           <MenuSection
             id="alerts"
             icon={<BellIcon />}
@@ -99,6 +107,8 @@ export default function Page() {
             />
           </MenuSection>
 
+          <Separator className="my-5" />
+
           <MenuSection
             id="background"
             icon={<ComponentBooleanIcon />}
@@ -106,7 +116,10 @@ export default function Page() {
           >
             <ThemeSelect />
             <CustomTheme />
+            <MenuSelectColor/>
           </MenuSection>
+
+          <Separator className="my-5" />
 
           <MenuSection
             id="app-data"
@@ -115,6 +128,8 @@ export default function Page() {
           >
             <DataImportExport />
           </MenuSection>
+
+          <Separator className="my-5" />
 
           <MenuSection
             id="preferences"

--- a/src/app/transfer-solves/page.tsx
+++ b/src/app/transfer-solves/page.tsx
@@ -174,7 +174,7 @@ export default function TransferSolvesPage() {
                     });
                   }}
                   className={
-                    `relative grow flex items-center justify-center w-auto font-medium text-center transition duration-200 rounded-md cursor-pointer h-full bg-secondary text-secondary-foreground hover:opacity-70 ${selectedSolves.find((solve) => solve === displaySolves[index].id) ? "ring ring-blue-600" : ""}`
+                    `relative grow flex items-center justify-center w-auto font-medium text-center transition duration-200 rounded-md cursor-pointer h-full bg-secondary text-secondary-foreground hover:opacity-70 ${selectedSolves.find((solve) => solve === displaySolves[index].id) ? "ring ring-primary" : ""}`
                   }
                 >
                   <div className="tracking-wider pt-2">

--- a/src/components/PreloadSettings.tsx
+++ b/src/components/PreloadSettings.tsx
@@ -18,7 +18,7 @@ export default function PreloadSettings({
       <ThemeProvider
         attribute="class"
         defaultTheme={"system"}
-        // enableSystem
+        enableSystem
         disableTransitionOnChange
       >
         <div

--- a/src/components/menu-settings/MenuSelectColor.tsx
+++ b/src/components/menu-settings/MenuSelectColor.tsx
@@ -1,0 +1,58 @@
+import { Colors } from "@/interfaces/types/colors";
+import { setSetting } from "@/lib/settingsUtils";
+import { useSettingsModalStore } from "@/store/SettingsModalStore";
+import loadSettings from "@/lib/loadSettings";
+import useWebsiteColors from "@/hooks/useWebsiteColors";
+
+export default function MenuSelectColor() {
+  const { settings, setSettings } = useSettingsModalStore();
+  const { applyColorTheme } = useWebsiteColors();
+
+  const handleChooseColor = (newColor: Colors) => {
+    const colorTheme = settings.preferences.colorTheme.key;
+    setSetting(colorTheme, newColor);
+    setSettings(loadSettings());
+    applyColorTheme(newColor);
+  };
+
+  const currentColor = settings.preferences.colorTheme.value;
+
+  return (
+    <div className="flex flex-col gap-2 px-2 mt-5">
+      <div className="flex flex-wrap gap-2">
+        <div
+          className={`size-10 rounded-full bg-red-500 hover:bg-red-600 focus:outline-none ${currentColor === 'red' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("red")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-orange-500 hover:bg-orange-600 focus:outline-none ${currentColor === 'orange' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("orange")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-yellow-500 hover:bg-yellow-600 focus:outline-none ${currentColor === 'yellow' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("yellow")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-green-500 hover:bg-green-600 focus:outline-none ${currentColor === 'green' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("green")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-blue-500 hover:bg-blue-600 focus:outline-none ${currentColor === 'blue' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("blue")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-violet-500 hover:bg-violet-600 focus:outline-none ${currentColor === 'violet' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("violet")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-rose-500 hover:bg-rose-600 focus:outline-none ${currentColor === 'rose' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("rose")}
+        ></div>
+        <div
+          className={`size-10 rounded-full bg-neutral-500 hover:bg-neutral-600 focus:outline-none ${currentColor === 'neutral' ? 'ring' : ''}`}
+          onClick={() => handleChooseColor("neutral")}
+        ></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/navigation/buttons/button-navbar.tsx
+++ b/src/components/navigation/buttons/button-navbar.tsx
@@ -2,6 +2,7 @@
 import { Button } from "@/components/ui/button";
 
 import * as React from "react";
+import { useEffect } from "react";
 
 import {
   CommandDialog,
@@ -10,7 +11,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-  CommandSeparator,
+  CommandSeparator
 } from "@/components/ui/command";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { DialogTitle } from "@/components/ui/dialog";
@@ -25,7 +26,7 @@ import {
   MoonIcon,
   PersonIcon,
   SunIcon,
-  TokensIcon,
+  TokensIcon
 } from "@radix-ui/react-icons";
 
 import { ArrowRightLeftIcon } from "lucide-react";
@@ -36,6 +37,8 @@ import { useTheme } from "next-themes";
 import genId from "@/lib/genId";
 import { useTranslations } from "next-intl";
 import { useFullScreen } from "@/hooks/useFullScreen";
+import useWebsiteColors from "@/hooks/useWebsiteColors";
+import loadSettings from "@/lib/loadSettings";
 
 interface ListItem {
   icon: React.ReactNode;
@@ -53,7 +56,9 @@ export default function ButtonNavbar() {
   const [open, setOpen] = React.useState(false);
   const { setTheme } = useTheme();
   const { toggleFullScreen } = useFullScreen();
-  React.useEffect(() => {
+  const { applyColorTheme } = useWebsiteColors();
+
+  useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -77,51 +82,56 @@ export default function ButtonNavbar() {
           />
         ),
         name: t("HomePage.title"),
-        url: "/",
+        url: "/"
       },
       {
-        icon: <TokensIcon />,
+        icon: <TokensIcon/>,
         name: t("SolvesPage.title"),
-        url: "/solves",
+        url: "/solves"
       },
       {
-        icon: <BarChartIcon />,
+        icon: <BarChartIcon/>,
         name: t("StatsPage.title"),
-        url: "/stats",
+        url: "/stats"
       },
       {
-        icon: <CubeIcon />,
+        icon: <CubeIcon/>,
         name: t("CubesPage.title"),
-        url: "/cubes",
+        url: "/cubes"
       },
       {
         icon: <ArrowRightLeftIcon/>,
         name: "Transfer Solves",
-        url: "/transfer-solves",
+        url: "/transfer-solves"
       },
       {
-        icon: <MixerHorizontalIcon />,
+        icon: <MixerHorizontalIcon/>,
         name: t("SettingsPage.title"),
-        url: "/settings",
-      },
+        url: "/settings"
+      }
     ],
     account: [
       {
-        icon: <PersonIcon />,
+        icon: <PersonIcon/>,
         name: t("SettingsPage.account"),
-        url: "/settings/account",
+        url: "/settings/account"
       },
       {
-        icon: <CircleIcon />,
+        icon: <CircleIcon/>,
         name: t("SettingsPage.save-data-title"),
-        url: "/settings/account/save",
+        url: "/settings/account/save"
       },
       {
-        icon: <CircleIcon />,
+        icon: <CircleIcon/>,
         name: t("SettingsPage.load-data-title"),
-        url: "/settings/account/load",
-      },
-    ],
+        url: "/settings/account/load"
+      }
+    ]
+  };
+
+  const handleThemeChange = (theme: string) => {
+    setTheme(theme);
+    applyColorTheme(loadSettings().preferences.colorTheme.value);
   };
 
   return (
@@ -143,7 +153,7 @@ export default function ButtonNavbar() {
         <VisuallyHidden.Root>
           <DialogTitle>NexusTimer Navigation</DialogTitle>
         </VisuallyHidden.Root>
-        <CommandInput placeholder={t("Inputs.search")} />
+        <CommandInput placeholder={t("Inputs.search")}/>
         <CommandList>
           <CommandEmpty>{t("Inputs.no-results")}</CommandEmpty>
           <CommandGroup heading={t("others.suggestions")}>
@@ -159,11 +169,11 @@ export default function ButtonNavbar() {
               );
             })}
             <CommandItem onSelect={() => toggleFullScreen()}>
-              <EnterFullScreenIcon />
+              <EnterFullScreenIcon/>
               Fullscreen
             </CommandItem>
           </CommandGroup>
-          <CommandSeparator />
+          <CommandSeparator/>
           <CommandGroup heading={t("SettingsPage.account")}>
             {list.account.map((c) => {
               return (
@@ -176,18 +186,18 @@ export default function ButtonNavbar() {
               );
             })}
           </CommandGroup>
-          <CommandSeparator />
+          <CommandSeparator/>
           <CommandGroup heading={t("Settings-menu.theme")}>
-            <CommandItem onPointerDown={() => setTheme("light")}>
-              <SunIcon />
+            <CommandItem onPointerDown={() => handleThemeChange("light")}>
+              <SunIcon/>
               {t("Settings-menu.light")}
             </CommandItem>
-            <CommandItem onPointerDown={() => setTheme("dark")}>
-              <MoonIcon />
+            <CommandItem onPointerDown={() => handleThemeChange("dark")}>
+              <MoonIcon/>
               {t("Settings-menu.dark")}
             </CommandItem>
-            <CommandItem onPointerDown={() => setTheme("system")}>
-              <DesktopIcon />
+            <CommandItem onPointerDown={() => handleThemeChange("system")}>
+              <DesktopIcon/>
               {t("Settings-menu.system")}
             </CommandItem>
           </CommandGroup>
@@ -201,7 +211,7 @@ function CommandLink({
   url,
   label,
   icon,
-  disabled = false,
+  disabled = false
 }: {
   url: string;
   label: string;

--- a/src/hooks/useWebsiteColors.ts
+++ b/src/hooks/useWebsiteColors.ts
@@ -1,0 +1,490 @@
+import { Colors } from "@/interfaces/types/colors";
+import { useTheme } from "next-themes";
+import { useEffect } from "react";
+import loadSettings from "@/lib/loadSettings";
+
+export default function useWebsiteColors() {
+  const colors = {
+    yellow: {
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "20 14.3% 4.1%",
+          card: "0 0% 100%",
+          "card-foreground": "20 14.3% 4.1%",
+          popover: "0 0% 100%",
+          "popover-foreground": "20 14.3% 4.1%",
+          primary: "47.9 95.8% 53.1%",
+          "primary-foreground": "26 83.3% 14.1%",
+          secondary: "60 4.8% 95.9%",
+          "secondary-foreground": "24 9.8% 10%",
+          muted: "60 4.8% 95.9%",
+          "muted-foreground": "25 5.3% 44.7%",
+          accent: "60 4.8% 95.9%",
+          "accent-foreground": "24 9.8% 10%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "60 9.1% 97.8%",
+          border: "20 5.9% 90%",
+          input: "20 5.9% 90%",
+          ring: "20 14.3% 4.1%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "20 14.3% 4.1%",
+          foreground: "60 9.1% 97.8%",
+          card: "20 14.3% 4.1%",
+          "card-foreground": "60 9.1% 97.8%",
+          popover: "20 14.3% 4.1%",
+          "popover-foreground": "60 9.1% 97.8%",
+          primary: "47.9 95.8% 53.1%",
+          "primary-foreground": "26 83.3% 14.1%",
+          secondary: "12 6.5% 15.1%",
+          "secondary-foreground": "60 9.1% 97.8%",
+          muted: "12 6.5% 15.1%",
+          "muted-foreground": "24 5.4% 63.9%",
+          accent: "12 6.5% 15.1%",
+          "accent-foreground": "60 9.1% 97.8%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "60 9.1% 97.8%",
+          border: "12 6.5% 15.1%",
+          input: "12 6.5% 15.1%",
+          ring: "35.5 91.7% 32.9%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    },
+    blue: {
+      "base": {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "222.2 84% 4.9%",
+          card: "0 0% 100%",
+          "card-foreground": "222.2 84% 4.9%",
+          popover: "0 0% 100%",
+          "popover-foreground": "222.2 84% 4.9%",
+          primary: "221.2 83.2% 53.3%",
+          "primary-foreground": "210 40% 98%",
+          secondary: "210 40% 96.1%",
+          "secondary-foreground": "222.2 47.4% 11.2%",
+          muted: "210 40% 96.1%",
+          "muted-foreground": "215.4 16.3% 46.9%",
+          accent: "210 40% 96.1%",
+          "accent-foreground": "222.2 47.4% 11.2%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "210 40% 98%",
+          border: "214.3 31.8% 91.4%",
+          input: "214.3 31.8% 91.4%",
+          ring: "221.2 83.2% 53.3%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "222.2 84% 4.9%",
+          foreground: "210 40% 98%",
+          card: "222.2 84% 4.9%",
+          "card-foreground": "210 40% 98%",
+          popover: "222.2 84% 4.9%",
+          "popover-foreground": "210 40% 98%",
+          primary: "217.2 91.2% 59.8%",
+          "primary-foreground": "222.2 47.4% 11.2%",
+          secondary: "217.2 32.6% 17.5%",
+          "secondary-foreground": "210 40% 98%",
+          muted: "217.2 32.6% 17.5%",
+          "muted-foreground": "215 20.2% 65.1%",
+          accent: "217.2 32.6% 17.5%",
+          "accent-foreground": "210 40% 98%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "210 40% 98%",
+          border: "217.2 32.6% 17.5%",
+          input: "217.2 32.6% 17.5%",
+          ring: "224.3 76.3% 48%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    },
+    green: {
+
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "240 10% 3.9%",
+          card: "0 0% 100%",
+          "card-foreground": "240 10% 3.9%",
+          popover: "0 0% 100%",
+          "popover-foreground": "240 10% 3.9%",
+          primary: "142.1 76.2% 36.3%",
+          "primary-foreground": "355.7 100% 97.3%",
+          secondary: "240 4.8% 95.9%",
+          "secondary-foreground": "240 5.9% 10%",
+          muted: "240 4.8% 95.9%",
+          "muted-foreground": "240 3.8% 46.1%",
+          accent: "240 4.8% 95.9%",
+          "accent-foreground": "240 5.9% 10%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "0 0% 98%",
+          border: "240 5.9% 90%",
+          input: "240 5.9% 90%",
+          ring: "142.1 76.2% 36.3%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "20 14.3% 4.1%",
+          foreground: "0 0% 95%",
+          card: "24 9.8% 10%",
+          "card-foreground": "0 0% 95%",
+          popover: "0 0% 9%",
+          "popover-foreground": "0 0% 95%",
+          primary: "142.1 70.6% 45.3%",
+          "primary-foreground": "144.9 80.4% 10%",
+          secondary: "240 3.7% 15.9%",
+          "secondary-foreground": "0 0% 98%",
+          muted: "0 0% 15%",
+          "muted-foreground": "240 5% 64.9%",
+          accent: "12 6.5% 15.1%",
+          "accent-foreground": "0 0% 98%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "0 85.7% 97.3%",
+          border: "240 3.7% 15.9%",
+          input: "240 3.7% 15.9%",
+          ring: "142.4 71.8% 29.2%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    },
+    violet: {
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "224 71.4% 4.1%",
+          card: "0 0% 100%",
+          "card-foreground": "224 71.4% 4.1%",
+          popover: "0 0% 100%",
+          "popover-foreground": "224 71.4% 4.1%",
+          primary: "262.1 83.3% 57.8%",
+          "primary-foreground": "210 20% 98%",
+          secondary: "220 14.3% 95.9%",
+          "secondary-foreground": "220.9 39.3% 11%",
+          muted: "220 14.3% 95.9%",
+          "muted-foreground": "220 8.9% 46.1%",
+          accent: "220 14.3% 95.9%",
+          "accent-foreground": "220.9 39.3% 11%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "210 20% 98%",
+          border: "220 13% 91%",
+          input: "220 13% 91%",
+          ring: "262.1 83.3% 57.8%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "224 71.4% 4.1%",
+          foreground: "210 20% 98%",
+          card: "224 71.4% 4.1%",
+          "card-foreground": "210 20% 98%",
+          popover: "224 71.4% 4.1%",
+          "popover-foreground": "210 20% 98%",
+          primary: "263.4 70% 50.4%",
+          "primary-foreground": "210 20% 98%",
+          secondary: "215 27.9% 16.9%",
+          "secondary-foreground": "210 20% 98%",
+          muted: "215 27.9% 16.9%",
+          "muted-foreground": "217.9 10.6% 64.9%",
+          accent: "215 27.9% 16.9%",
+          "accent-foreground": "210 20% 98%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "210 20% 98%",
+          border: "215 27.9% 16.9%",
+          input: "215 27.9% 16.9%",
+          ring: "263.4 70% 50.4%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    },
+    orange: {
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "20 14.3% 4.1%",
+          card: "0 0% 100%",
+          "card-foreground": "20 14.3% 4.1%",
+          popover: "0 0% 100%",
+          "popover-foreground": "20 14.3% 4.1%",
+          primary: "24.6 95% 53.1%",
+          "primary-foreground": "60 9.1% 97.8%",
+          secondary: "60 4.8% 95.9%",
+          "secondary-foreground": "24 9.8% 10%",
+          muted: "60 4.8% 95.9%",
+          "muted-foreground": "25 5.3% 44.7%",
+          accent: "60 4.8% 95.9%",
+          "accent-foreground": "24 9.8% 10%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "60 9.1% 97.8%",
+          border: "20 5.9% 90%",
+          input: "20 5.9% 90%",
+          ring: "24.6 95% 53.1%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "20 14.3% 4.1%",
+          foreground: "60 9.1% 97.8%",
+          card: "20 14.3% 4.1%",
+          "card-foreground": "60 9.1% 97.8%",
+          popover: "20 14.3% 4.1%",
+          "popover-foreground": "60 9.1% 97.8%",
+          primary: "20.5 90.2% 48.2%",
+          "primary-foreground": "60 9.1% 97.8%",
+          secondary: "12 6.5% 15.1%",
+          "secondary-foreground": "60 9.1% 97.8%",
+          muted: "12 6.5% 15.1%",
+          "muted-foreground": "24 5.4% 63.9%",
+          accent: "12 6.5% 15.1%",
+          "accent-foreground": "60 9.1% 97.8%",
+          destructive: "0 72.2% 50.6%",
+          "destructive-foreground": "60 9.1% 97.8%",
+          border: "12 6.5% 15.1%",
+          input: "12 6.5% 15.1%",
+          ring: "20.5 90.2% 48.2%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+
+      }
+    },
+    rose: {
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "240 10% 3.9%",
+          card: "0 0% 100%",
+          "card-foreground": "240 10% 3.9%",
+          popover: "0 0% 100%",
+          "popover-foreground": "240 10% 3.9%",
+          primary: "346.8 77.2% 49.8%",
+          "primary-foreground": "355.7 100% 97.3%",
+          secondary: "240 4.8% 95.9%",
+          "secondary-foreground": "240 5.9% 10%",
+          muted: "240 4.8% 95.9%",
+          "muted-foreground": "240 3.8% 46.1%",
+          accent: "240 4.8% 95.9%",
+          "accent-foreground": "240 5.9% 10%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "0 0% 98%",
+          border: "240 5.9% 90%",
+          input: "240 5.9% 90%",
+          ring: "346.8 77.2% 49.8%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "20 14.3% 4.1%",
+          foreground: "0 0% 95%",
+          card: "24 9.8% 10%",
+          "card-foreground": "0 0% 95%",
+          popover: "0 0% 9%",
+          "popover-foreground": "0 0% 95%",
+          primary: "346.8 77.2% 49.8%",
+          "primary-foreground": "355.7 100% 97.3%",
+          secondary: "240 3.7% 15.9%",
+          "secondary-foreground": "0 0% 98%",
+          muted: "0 0% 15%",
+          "muted-foreground": "240 5% 64.9%",
+          accent: "12 6.5% 15.1%",
+          "accent-foreground": "0 0% 98%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "0 85.7% 97.3%",
+          border: "240 3.7% 15.9%",
+          input: "240 3.7% 15.9%",
+          ring: "346.8 77.2% 49.8%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    },
+    neutral: {
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "0 0% 3.9%",
+          card: "0 0% 100%",
+          "card-foreground": "0 0% 3.9%",
+          popover: "0 0% 100%",
+          "popover-foreground": "0 0% 3.9%",
+          primary: "0 0% 9%",
+          "primary-foreground": "0 0% 98%",
+          secondary: "0 0% 96.1%",
+          "secondary-foreground": "0 0% 9%",
+          muted: "0 0% 96.1%",
+          "muted-foreground": "0 0% 45.1%",
+          accent: "0 0% 96.1%",
+          "accent-foreground": "0 0% 9%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "0 0% 98%",
+          border: "0 0% 89.8%",
+          input: "0 0% 89.8%",
+          ring: "0 0% 3.9%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "0 0% 3.9%",
+          foreground: "0 0% 98%",
+          card: "0 0% 3.9%",
+          "card-foreground": "0 0% 98%",
+          popover: "0 0% 3.9%",
+          "popover-foreground": "0 0% 98%",
+          primary: "0 0% 98%",
+          "primary-foreground": "0 0% 9%",
+          secondary: "0 0% 14.9%",
+          "secondary-foreground": "0 0% 98%",
+          muted: "0 0% 14.9%",
+          "muted-foreground": "0 0% 63.9%",
+          accent: "0 0% 14.9%",
+          "accent-foreground": "0 0% 98%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "0 0% 98%",
+          border: "0 0% 14.9%",
+          input: "0 0% 14.9%",
+          ring: "0 0% 83.1%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    },
+    red: {
+      base: {
+        ":root": {
+          background: "0 0% 100%",
+          foreground: "0 0% 3.9%",
+          card: "0 0% 100%",
+          "card-foreground": "0 0% 3.9%",
+          popover: "0 0% 100%",
+          "popover-foreground": "0 0% 3.9%",
+          primary: "0 72.2% 50.6%",
+          "primary-foreground": "0 85.7% 97.3%",
+          secondary: "0 0% 96.1%",
+          "secondary-foreground": "0 0% 9%",
+          muted: "0 0% 96.1%",
+          "muted-foreground": "0 0% 45.1%",
+          accent: "0 0% 96.1%",
+          "accent-foreground": "0 0% 9%",
+          destructive: "0 84.2% 60.2%",
+          "destructive-foreground": "0 0% 98%",
+          border: "0 0% 89.8%",
+          input: "0 0% 89.8%",
+          ring: "0 72.2% 50.6%",
+          radius: "0.5rem",
+          "chart-1": "12 76% 61%",
+          "chart-2": "173 58% 39%",
+          "chart-3": "197 37% 24%",
+          "chart-4": "43 74% 66%",
+          "chart-5": "27 87% 67%"
+        },
+        ".dark": {
+          background: "0 0% 3.9%",
+          foreground: "0 0% 98%",
+          card: "0 0% 3.9%",
+          "card-foreground": "0 0% 98%",
+          popover: "0 0% 3.9%",
+          "popover-foreground": "0 0% 98%",
+          primary: "0 72.2% 50.6%",
+          "primary-foreground": "0 85.7% 97.3%",
+          secondary: "0 0% 14.9%",
+          "secondary-foreground": "0 0% 98%",
+          muted: "0 0% 14.9%",
+          "muted-foreground": "0 0% 63.9%",
+          accent: "0 0% 14.9%",
+          "accent-foreground": "0 0% 98%",
+          destructive: "0 62.8% 30.6%",
+          "destructive-foreground": "0 0% 98%",
+          border: "0 0% 14.9%",
+          input: "0 0% 14.9%",
+          ring: "0 72.2% 50.6%",
+          "chart-1": "220 70% 50%",
+          "chart-2": "160 60% 45%",
+          "chart-3": "30 80% 55%",
+          "chart-4": "280 65% 60%",
+          "chart-5": "340 75% 55%"
+        }
+      }
+    }
+  };
+
+  const { resolvedTheme } = useTheme();
+
+  const applyColorTheme = (color: Colors) => {
+    const colorConfig = colors[color as keyof typeof colors]?.base;
+    if (!colorConfig) return;
+
+    if (resolvedTheme === "light") {
+      Object.entries(colorConfig[":root"] || {}).forEach(([key, value]) => {
+        document.documentElement.style.setProperty(`--${key}`, value as string);
+      });
+    } else if (resolvedTheme === "dark") {
+      Object.entries(colorConfig[".dark"] || {}).forEach(([key, value]) => {
+        document.documentElement.style.setProperty(`--${key}`, value as string);
+      });
+    }
+  };
+
+  useEffect(() => {
+    applyColorTheme(loadSettings().preferences.colorTheme.value);
+  }, [applyColorTheme, resolvedTheme]);
+
+  return { applyColorTheme };
+}

--- a/src/interfaces/Settings.ts
+++ b/src/interfaces/Settings.ts
@@ -1,3 +1,5 @@
+import { Colors } from "@/interfaces/types/colors";
+
 interface Timer {
   inspection: { status: boolean; key: string };
   startCue: { status: boolean; key: string };
@@ -21,6 +23,7 @@ interface Alerts {
 
 interface Preferences {
   defaultCube: { id: string | null; key: string };
+  colorTheme: { value: Colors; key: string };
 }
 
 export interface Settings {

--- a/src/interfaces/types/colors.ts
+++ b/src/interfaces/types/colors.ts
@@ -1,0 +1,1 @@
+export type Colors = "green" | "neutral" | "violet" | "red" | "yellow" | "orange" | "blue" | "rose";

--- a/src/lib/const/defaultSettings.ts
+++ b/src/lib/const/defaultSettings.ts
@@ -21,5 +21,6 @@ export const defaultSettings: Settings = {
   },
   preferences: {
     defaultCube: { id: null, key: "default-cube" },
+    colorTheme: { value: "blue", key: "color-theme" },
   },
 };

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -50,6 +50,7 @@ export function buildSettingsObject(): Settings {
   });
 
   settings.preferences.defaultCube.id = getSetting(settings.preferences.defaultCube.key, settings.preferences.defaultCube.id);
+  settings.preferences.colorTheme.value = getSetting(settings.preferences.colorTheme.key, settings.preferences.colorTheme.value);
 
   return settings;
 }


### PR DESCRIPTION
**What does this PR do?**
Introduces support for a customizable color palette within the UI. Users can now define and apply their own color schemes to better match their personal preferences.

**Screenshots or GIFs (if applicable)**
![image](https://github.com/user-attachments/assets/4c66dc4e-ca55-4486-b7da-c447611d62bb)

**By submitting this PR, I confirm that:**
- [X] I have reviewed my code and believe it is ready for merging.
- [X] I understand that this PR may be subject to review and changes.
- [X] I agree to abide by the code of conduct and contributing guidelines of this project.
