### PR TITLE
refactor: improve modularity of timer core logic

### DIFF
--- a/src/components/timer/Timer.tsx
+++ b/src/components/timer/Timer.tsx
@@ -9,6 +9,7 @@ import DisplayContainer from "./display/display-container";
 import DisplayTime from "./display/display-time";
 import { ReactNode } from "react";
 import { TimerStatus } from "@/enums/TimerStatus";
+import useSolveData from "@/hooks/useSolveData";
 
 export default function Timer({ children }: { children?: ReactNode }) {
   const { settings } = useSettingsModalStore();
@@ -20,8 +21,30 @@ export default function Timer({ children }: { children?: ReactNode }) {
     solvingTime,
     timerStatistics,
     setLastSolve,
+    setTimerStatus,
+    setTimerStatistics,
+    setIsSolving,
+    setSolvingTime,
+    displayHint,
+    timerMode
   } = useTimerStore();
-  const { inspectionTime } = useTimer();
+
+  const { saveSolveMainTimer } = useSolveData();
+
+  const { inspectionTime } = useTimer({
+    onFinishSolve: () => saveSolveMainTimer(),
+    isSolving,
+    setTimerStatus,
+    selectedCube,
+    setTimerStatistics,
+    inspectionRequired: settings.timer.inspection.status,
+    setIsSolving,
+    setSolvingTime,
+    displayHint,
+    timerMode,
+    settings
+  });
+
   const { device } = useDeviceMatch();
 
   return (

--- a/src/hooks/useEventHandlers.ts
+++ b/src/hooks/useEventHandlers.ts
@@ -1,17 +1,25 @@
 import { useRef, useEffect, useCallback } from "react";
-import { useTimerStore } from "@/store/timerStore";
 import { TimerMode } from "@/enums/TimerMode";
 
 type HandleHoldFunction = (isReleased: boolean) => void;
 type HandleReleaseFunction = () => void;
 type ResetTimerFunction = () => void;
 
-export default function useEventHandlers(
-  handleHold: HandleHoldFunction,
-  handleRelease: HandleReleaseFunction,
-  resetTimer: ResetTimerFunction
-) {
-  const { displayHint, timerMode } = useTimerStore();
+interface UseEventHandlersProps {
+  displayHint: boolean;
+  timerMode: TimerMode;
+  handleHold: HandleHoldFunction;
+  handleRelease: HandleReleaseFunction;
+  resetTimer: ResetTimerFunction;
+}
+
+export default function useEventHandlers({
+  displayHint,
+  timerMode,
+  handleHold,
+  handleRelease,
+  resetTimer
+}: UseEventHandlersProps) {
   const releasedKey = useRef<boolean>(true);
 
   const handleHoldWithReleasedState = useCallback(() => {

--- a/src/hooks/useHoldToStart.ts
+++ b/src/hooks/useHoldToStart.ts
@@ -1,12 +1,16 @@
 import { useRef, useState } from "react";
-import { useTimerStore } from "@/store/timerStore";
-import { useSettingsModalStore } from "@/store/SettingsModalStore";
 import { TimerStatus } from "@/enums/TimerStatus";
 
-export default function useHoldToStart() {
-  const { setTimerStatus } = useTimerStore();
-  const { settings } = useSettingsModalStore();
-  
+interface UseHoldToStartProps {
+  setTimerStatus: (status: TimerStatus) => void;
+  settings: any;
+}
+
+export default function useHoldToStart({
+  setTimerStatus,
+  settings
+}: UseHoldToStartProps) {
+
   const holdTimeRequired = settings.timer.holdToStart.status ? 500 : 0;
   const startHoldingTime = useRef<number | null>(null);
   const holdingTimeId = useRef<any>(null);

--- a/src/hooks/useInspection.ts
+++ b/src/hooks/useInspection.ts
@@ -1,12 +1,18 @@
 import { useRef, useState } from "react";
-import { useTimerStore } from "@/store/timerStore";
-import { useSettingsModalStore } from "@/store/SettingsModalStore";
 import { TimerStatus } from "@/enums/TimerStatus";
 
-export default function useInspection() {
-  const { setTimerStatus, setSolvingTime } = useTimerStore();
-  const { settings } = useSettingsModalStore();
-  
+interface UseInspectionProps {
+  setTimerStatus: (status: TimerStatus) => void;
+  setSolvingTime: (time: number) => void;
+  settings: any;
+}
+
+export default function useInspection({
+  setTimerStatus,
+  setSolvingTime,
+  settings
+}: UseInspectionProps) {
+
   const inspectionDuration = 16000;
   const startInspectionTime = useRef<number | null>(null);
   const inspectionId = useRef<any>(null);

--- a/src/hooks/useSolveData.ts
+++ b/src/hooks/useSolveData.ts
@@ -15,11 +15,11 @@ export default function useSolveData() {
     cubes,
   } = useTimerStore();
 
-  const saveSolveData = async (startTime: number) => {
+  const saveSolveMainTimer = async () => {
     if (selectedCube && scramble) {
       const lastSolve: Solve = {
         id: genId(),
-        startTime: startTime,
+        startTime: Date.now() - solvingTime,
         endTime: Date.now(),
         scramble: scramble,
         bookmark: false,
@@ -51,11 +51,11 @@ export default function useSolveData() {
       const updatedCube = await getCubeById(selectedCube.id);
       setSelectedCube(updatedCube);
     }
-    
+
     setNewScramble(selectedCube);
   };
 
   return {
-    saveSolveData,
+    saveSolveMainTimer,
   };
 }


### PR DESCRIPTION
**What does this PR do?**
Refactored the timer core logic to make it more modular. Instead of using Zustand store values directly inside the core, it now takes them as props. This makes it easier to reuse the timer in different modes. (Coming clash mode).

Also replaced `Date.now()` with `performance.now()` for more accurate and consistent timing.

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
