### PR TITLE
feat(formatTime): add support for configurable decimal places

### DIFF
--- a/src/lib/formatTime.ts
+++ b/src/lib/formatTime.ts
@@ -2,16 +2,17 @@
  * Converts a time duration in milliseconds to a formatted string in "mm:ss.SS" format.
  *
  * @param {number} timeInMs - The time duration in milliseconds.
+ * @param {number} decimals - The number of decimal places to display (default: 2).
  * @returns {string} The formatted time string.
  */
-export default function formatTime(timeInMs: number): string {
+export default function formatTime(timeInMs: number, decimals: number = 2): string {
   /**
    * Pads a number to have at least 2 digits by adding leading zeros.
    *
    * @param {number} num - The number to pad.
    * @returns {string} The padded number as a string.
    */
-  function padTo2Digits(num: number) {
+  function padTo2Digits(num: number): string {
     return num.toString().padStart(2, "0");
   }
 
@@ -19,10 +20,11 @@ export default function formatTime(timeInMs: number): string {
   const seconds = Math.floor((timeInMs / 1000) % 60);
   const minutes = Math.floor((timeInMs / (60 * 1000)) % 60);
 
-  const formattedTime =
-    (minutes > 0 ? minutes + ":" + padTo2Digits(seconds) : seconds) +
-    "." +
-    (milliseconds / 1000).toFixed(2).slice(2);
+  let millisecondsFormatted = "";
+  if (decimals > 0) {
+    millisecondsFormatted = (milliseconds / 1000).toFixed(decimals).substring(2);
+  }
 
-  return formattedTime;
+  return (minutes > 0 ? minutes + ":" + padTo2Digits(seconds) : seconds) +
+    (millisecondsFormatted ? "." + millisecondsFormatted : "");
 }


### PR DESCRIPTION
**What does this PR do?**
Enhanced the `formatTime` function to allow specifying the number of decimal places for the milliseconds portion, defaulting to 2. Adjusted the internal logic to handle cases where no decimals are desired. This improves flexibility for use cases with varying precision requirements.


**Screenshots or GIFs (if applicable)**

https://github.com/user-attachments/assets/e67cdd44-d9d7-48b0-b168-386f608cac33



**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
