### PR TITLE
feat: generate dynamic color schemes

### DIFF
--- a/src/app/settings/account/load/page.tsx
+++ b/src/app/settings/account/load/page.tsx
@@ -78,16 +78,16 @@ export default function Page() {
     });
 
     // Clear app storage
-    cubes.forEach(async (c: Cube) => {
+    for (const c of cubes) {
       await deleteCubeById(c.id);
-    });
+    }
 
     // Replace storage with new Object Backup
-    newBackup.forEach(async (c: Cube) => {
+    for (const c of newBackup) {
       await saveCube({
         ...c,
       });
-    });
+    }
 
     // Update global state
     const appData = await getAllCubes();
@@ -107,13 +107,13 @@ export default function Page() {
         <p className="text-yellow-600">{t("SettingsPage.load-data-warning")}</p>
 
         <div className="flex gap-2 w-full justify-between mt-5 flex-col-reverse sm:flex-row">
-          <Link href={"./"} className="w-full">
+          <Link href={"./"} className="flex-1">
             <Button className="w-full" variant={"secondary"}>
               {t("Inputs.back")}
             </Button>
           </Link>
 
-          <Button className="w-full" onClick={handleDownloadData}>
+          <Button className="flex-1" onClick={handleDownloadData}>
             {t("Inputs.continue")}
           </Button>
         </div>

--- a/src/app/settings/account/save/page.tsx
+++ b/src/app/settings/account/save/page.tsx
@@ -23,13 +23,13 @@ export default function Page() {
         <p className="text-yellow-600">{t("SettingsPage.save-data-warning")}</p>
 
         <div className="flex gap-2 w-full justify-between mt-5 flex-col-reverse sm:flex-row">
-          <Link href={"./"} className="w-full">
+          <Link href={"./"} className="grow">
             <Button variant={"secondary"} className="w-full">
               {t("Inputs.back")}
             </Button>
           </Link>
           <Button
-            className="w-full"
+            className="grow"
             onClick={async () => {
               const cubes = await getAllCubes();
               if (

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -27,7 +27,7 @@ export default function Navigation({
 }) {
   return (
     <>
-      <div className="w-full max-w-7xl border mx-auto flex flex-col rounded-lg bg-background/90 backdrop-blur-lg p-2 gap-2 mb-2 sticky top-1 left-0 z-50">
+      <div className="w-full max-w-7xl border mx-auto flex flex-col rounded-lg bg-background/50 backdrop-blur-lg p-2 gap-2 mb-2 sticky top-1 left-0 z-50">
         {(showMenu || showMainCubeSelector || showButtonNextScramble || showButtonDisplayType || showButtonCreateCollection || showButtonSelectMode) && (
           <div className="flex justify-center items-center gap-2">
             {showMenu && <ButtonNavbar/>}

--- a/src/hooks/useWebsiteColors.ts
+++ b/src/hooks/useWebsiteColors.ts
@@ -34,7 +34,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.795 0.184 86.047)",
+            "sidebar-primary-foreground": "oklch(0.421 0.095 57.708)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.795 0.184 86.047)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -44,7 +52,7 @@ export default function useWebsiteColors() {
             popover: "oklch(0.21 0.006 285.885)",
             "popover-foreground": "oklch(0.985 0 0)",
             primary: "oklch(0.795 0.184 86.047)",
-            "primary-foreground": "oklch(0.379 0.076 63.591)",
+            "primary-foreground": "oklch(0.421 0.095 57.708)",
             secondary: "oklch(0.274 0.006 286.033)",
             "secondary-foreground": "oklch(0.985 0 0)",
             muted: "oklch(0.274 0.006 286.033)",
@@ -60,7 +68,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.795 0.184 86.047)",
+            "sidebar-primary-foreground": "oklch(0.421 0.095 57.708)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.554 0.135 66.442)"
           }
         }
       },
@@ -91,7 +107,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.623 0.214 259.815)",
+            "sidebar-primary-foreground": "oklch(0.97 0.014 254.604)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.623 0.214 259.815)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -101,7 +125,7 @@ export default function useWebsiteColors() {
             popover: "oklch(0.21 0.006 285.885)",
             "popover-foreground": "oklch(0.985 0 0)",
             primary: "oklch(0.546 0.245 262.881)",
-            "primary-foreground": "oklch(0.89 0.046 264.918)",
+            "primary-foreground": "oklch(0.379 0.146 265.522)",
             secondary: "oklch(0.274 0.006 286.033)",
             "secondary-foreground": "oklch(0.985 0 0)",
             muted: "oklch(0.274 0.006 286.033)",
@@ -117,7 +141,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.546 0.245 262.881)",
+            "sidebar-primary-foreground": "oklch(0.379 0.146 265.522)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.488 0.243 264.376)"
           }
         }
       },
@@ -148,7 +180,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.723 0.219 149.579)",
+            "sidebar-primary-foreground": "oklch(0.982 0.018 155.826)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.723 0.219 149.579)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -158,7 +198,7 @@ export default function useWebsiteColors() {
             popover: "oklch(0.21 0.006 285.885)",
             "popover-foreground": "oklch(0.985 0 0)",
             primary: "oklch(0.696 0.17 162.48)",
-            "primary-foreground": "oklch(0.332 0.088 151.615)",
+            "primary-foreground": "oklch(0.393 0.095 152.535)",
             secondary: "oklch(0.274 0.006 286.033)",
             "secondary-foreground": "oklch(0.985 0 0)",
             muted: "oklch(0.274 0.006 286.033)",
@@ -174,7 +214,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.696 0.17 162.48)",
+            "sidebar-primary-foreground": "oklch(0.393 0.095 152.535)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.527 0.154 150.069)"
           }
         }
       },
@@ -205,7 +253,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.606 0.25 292.717)",
+            "sidebar-primary-foreground": "oklch(0.969 0.016 293.756)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.606 0.25 292.717)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -231,7 +287,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.541 0.281 293.009)",
+            "sidebar-primary-foreground": "oklch(0.969 0.016 293.756)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.541 0.281 293.009)"
           }
         }
       },
@@ -262,7 +326,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.705 0.213 47.604)",
+            "sidebar-primary-foreground": "oklch(0.98 0.016 73.684)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.705 0.213 47.604)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -288,7 +360,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.646 0.222 41.116)",
+            "sidebar-primary-foreground": "oklch(0.98 0.016 73.684)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.646 0.222 41.116)"
           }
 
         }
@@ -320,7 +400,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.645 0.246 16.439)",
+            "sidebar-primary-foreground": "oklch(0.969 0.015 12.422)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.645 0.246 16.439)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -346,7 +434,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.645 0.246 16.439)",
+            "sidebar-primary-foreground": "oklch(0.969 0.015 12.422)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.645 0.246 16.439)"
           }
         }
       },
@@ -448,7 +544,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.6 0.118 184.704)",
             "chart-3": "oklch(0.398 0.07 227.392)",
             "chart-4": "oklch(0.828 0.189 84.429)",
-            "chart-5": "oklch(0.769 0.188 70.08)"
+            "chart-5": "oklch(0.769 0.188 70.08)",
+            sidebar: "oklch(0.985 0 0)",
+            "sidebar-foreground": "oklch(0.141 0.005 285.823)",
+            "sidebar-primary": "oklch(0.637 0.237 25.331)",
+            "sidebar-primary-foreground": "oklch(0.971 0.013 17.38)",
+            "sidebar-accent": "oklch(0.967 0.001 286.375)",
+            "sidebar-accent-foreground": "oklch(0.21 0.006 285.885)",
+            "sidebar-border": "oklch(0.92 0.004 286.32)",
+            "sidebar-ring": "oklch(0.637 0.237 25.331)"
           },
           ".dark": {
             background: "oklch(0.141 0.005 285.823)",
@@ -474,7 +578,15 @@ export default function useWebsiteColors() {
             "chart-2": "oklch(0.696 0.17 162.48)",
             "chart-3": "oklch(0.769 0.188 70.08)",
             "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)"
+            "chart-5": "oklch(0.645 0.246 16.439)",
+            sidebar: "oklch(0.21 0.006 285.885)",
+            "sidebar-foreground": "oklch(0.985 0 0)",
+            "sidebar-primary": "oklch(0.637 0.237 25.331)",
+            "sidebar-primary-foreground": "oklch(0.971 0.013 17.38)",
+            "sidebar-accent": "oklch(0.274 0.006 286.033)",
+            "sidebar-accent-foreground": "oklch(0.985 0 0)",
+            "sidebar-border": "oklch(1 0 0 / 10%)",
+            "sidebar-ring": "oklch(0.637 0.237 25.331)"
           }
         }
       }

--- a/src/hooks/useWebsiteColors.ts
+++ b/src/hooks/useWebsiteColors.ts
@@ -5,6 +5,90 @@ import loadSettings from "@/lib/loadSettings";
 
 export default function useWebsiteColors() {
   const { resolvedTheme } = useTheme();
+
+  const generateDarkTheme = (lightTheme: Record<string, any>) => {
+    const primaryColor = lightTheme.primary;
+    const match = primaryColor.match(/oklch\(([0-9.]+) ([0-9.]+) ([0-9.]+)\)/);
+
+    if (!match) {
+      return {
+        background: "oklch(0.141 0.005 285.823)",
+        foreground: "oklch(0.985 0 0)",
+        card: "oklch(0.21 0.006 285.885)",
+        "card-foreground": "oklch(0.985 0 0)",
+        popover: "oklch(0.21 0.006 285.885)",
+        "popover-foreground": "oklch(0.985 0 0)",
+        primary: lightTheme.primary,
+        "primary-foreground": lightTheme["primary-foreground"],
+        secondary: "oklch(0.274 0.006 286.033)",
+        "secondary-foreground": "oklch(0.985 0 0)",
+        muted: "oklch(0.274 0.006 286.033)",
+        "muted-foreground": "oklch(0.705 0.015 286.067)",
+        accent: "oklch(0.274 0.006 286.033)",
+        "accent-foreground": "oklch(0.985 0 0)",
+        destructive: "oklch(0.704 0.191 22.216)",
+        "destructive-foreground": "oklch(0.985 0 0)",
+        border: "oklch(1 0 0 / 10%)",
+        input: "oklch(1 0 0 / 15%)",
+        ring: lightTheme.ring,
+        "chart-1": "oklch(0.488 0.243 264.376)",
+        "chart-2": "oklch(0.696 0.17 162.48)",
+        "chart-3": "oklch(0.769 0.188 70.08)",
+        "chart-4": "oklch(0.627 0.265 303.9)",
+        "chart-5": "oklch(0.645 0.246 16.439)",
+        sidebar: "oklch(0.21 0.006 285.885)",
+        "sidebar-foreground": "oklch(0.985 0 0)",
+        "sidebar-primary": lightTheme["sidebar-primary"],
+        "sidebar-primary-foreground": lightTheme["sidebar-primary-foreground"],
+        "sidebar-accent": "oklch(0.274 0.006 286.033)",
+        "sidebar-accent-foreground": "oklch(0.985 0 0)",
+        "sidebar-border": "oklch(1 0 0 / 10%)",
+        "sidebar-ring": lightTheme["sidebar-ring"]
+      };
+    }
+
+    const [_, lightness, chroma, hue] = match;
+
+    const veryDarkChroma = Math.min(parseFloat(chroma) * 0.15, 0.03);
+    const darkChroma = Math.min(parseFloat(chroma) * 0.25, 0.05);
+    const mediumChroma = Math.min(parseFloat(chroma) * 0.35, 0.07);
+
+    return {
+      background: `oklch(0.141 ${veryDarkChroma} ${hue})`,
+      foreground: "oklch(0.985 0 0)",
+      card: `oklch(0.21 ${darkChroma} ${hue})`,
+      "card-foreground": "oklch(0.985 0 0)",
+      popover: `oklch(0.21 ${darkChroma} ${hue})`,
+      "popover-foreground": "oklch(0.985 0 0)",
+      primary: lightTheme.primary,
+      "primary-foreground": lightTheme["primary-foreground"],
+      secondary: `oklch(0.274 ${mediumChroma} ${hue})`,
+      "secondary-foreground": "oklch(0.985 0 0)",
+      muted: `oklch(0.274 ${mediumChroma} ${hue})`,
+      "muted-foreground": `oklch(0.705 ${mediumChroma} ${hue})`,
+      accent: `oklch(0.274 ${mediumChroma} ${hue})`,
+      "accent-foreground": "oklch(0.985 0 0)",
+      destructive: "oklch(0.704 0.191 22.216)",
+      "destructive-foreground": "oklch(0.985 0 0)",
+      border: `oklch(0.7 ${veryDarkChroma} ${hue} / 20%)`,
+      input: `oklch(0.6 ${veryDarkChroma} ${hue} / 25%)`,
+      ring: lightTheme.ring,
+      "chart-1": "oklch(0.488 0.243 264.376)",
+      "chart-2": "oklch(0.696 0.17 162.48)",
+      "chart-3": "oklch(0.769 0.188 70.08)",
+      "chart-4": "oklch(0.627 0.265 303.9)",
+      "chart-5": "oklch(0.645 0.246 16.439)",
+      sidebar: `oklch(0.21 ${darkChroma} ${hue})`,
+      "sidebar-foreground": "oklch(0.985 0 0)",
+      "sidebar-primary": lightTheme["sidebar-primary"],
+      "sidebar-primary-foreground": lightTheme["sidebar-primary-foreground"],
+      "sidebar-accent": `oklch(0.274 ${mediumChroma} ${hue})`,
+      "sidebar-accent-foreground": "oklch(0.985 0 0)",
+      "sidebar-border": `oklch(0.3 ${veryDarkChroma} ${hue} / 20%)`,
+      "sidebar-ring": lightTheme["sidebar-ring"]
+    };
+  };
+
   const applyColorTheme = useCallback((color: Colors) => {
     const colors = {
       yellow: {
@@ -44,40 +128,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.795 0.184 86.047)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.795 0.184 86.047)",
             "primary-foreground": "oklch(0.421 0.095 57.708)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
             ring: "oklch(0.554 0.135 66.442)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.795 0.184 86.047)",
             "sidebar-primary-foreground": "oklch(0.421 0.095 57.708)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.554 0.135 66.442)"
-          }
+          })
         }
       },
       blue: {
@@ -117,40 +175,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.623 0.214 259.815)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.546 0.245 262.881)",
-            "primary-foreground": "oklch(0.379 0.146 265.522)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
+            "primary-foreground": "oklch(0.985 0 0)",
             ring: "oklch(0.488 0.243 264.376)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.546 0.245 262.881)",
             "sidebar-primary-foreground": "oklch(0.379 0.146 265.522)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.488 0.243 264.376)"
-          }
+          })
         }
       },
       green: {
@@ -190,40 +222,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.723 0.219 149.579)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.696 0.17 162.48)",
-            "primary-foreground": "oklch(0.393 0.095 152.535)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
+            "primary-foreground": "oklch(0.985 0 0)",
             ring: "oklch(0.527 0.154 150.069)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.696 0.17 162.48)",
             "sidebar-primary-foreground": "oklch(0.393 0.095 152.535)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.527 0.154 150.069)"
-          }
+          })
         }
       },
       violet: {
@@ -263,40 +269,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.606 0.25 292.717)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.541 0.281 293.009)",
-            "primary-foreground": "oklch(0.969 0.016 293.756)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
+            "primary-foreground": "oklch(0.985 0 0)",
             ring: "oklch(0.541 0.281 293.009)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.541 0.281 293.009)",
             "sidebar-primary-foreground": "oklch(0.969 0.016 293.756)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.541 0.281 293.009)"
-          }
+          })
         }
       },
       orange: {
@@ -336,40 +316,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.705 0.213 47.604)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.646 0.222 41.116)",
-            "primary-foreground": "oklch(0.98 0.016 73.684)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
+            "primary-foreground": "oklch(0.985 0 0)",
             ring: "oklch(0.646 0.222 41.116)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.646 0.222 41.116)",
             "sidebar-primary-foreground": "oklch(0.98 0.016 73.684)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.646 0.222 41.116)"
-          }
+          })
 
         }
       },
@@ -410,40 +364,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.645 0.246 16.439)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.645 0.246 16.439)",
-            "primary-foreground": "oklch(0.969 0.015 12.422)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
+            "primary-foreground": "oklch(0.985 0 0)",
             ring: "oklch(0.645 0.246 16.439)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.645 0.246 16.439)",
             "sidebar-primary-foreground": "oklch(0.969 0.015 12.422)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.645 0.246 16.439)"
-          }
+          })
         }
       },
       neutral: {
@@ -554,40 +482,14 @@ export default function useWebsiteColors() {
             "sidebar-border": "oklch(0.92 0.004 286.32)",
             "sidebar-ring": "oklch(0.637 0.237 25.331)"
           },
-          ".dark": {
-            background: "oklch(0.141 0.005 285.823)",
-            foreground: "oklch(0.985 0 0)",
-            card: "oklch(0.21 0.006 285.885)",
-            "card-foreground": "oklch(0.985 0 0)",
-            popover: "oklch(0.21 0.006 285.885)",
-            "popover-foreground": "oklch(0.985 0 0)",
+          ".dark": generateDarkTheme({
             primary: "oklch(0.637 0.237 25.331)",
-            "primary-foreground": "oklch(0.971 0.013 17.38)",
-            secondary: "oklch(0.274 0.006 286.033)",
-            "secondary-foreground": "oklch(0.985 0 0)",
-            muted: "oklch(0.274 0.006 286.033)",
-            "muted-foreground": "oklch(0.705 0.015 286.067)",
-            accent: "oklch(0.274 0.006 286.033)",
-            "accent-foreground": "oklch(0.985 0 0)",
-            destructive: "oklch(0.704 0.191 22.216)",
-            "destructive-foreground": "oklch(0.985 0 0)",
-            border: "oklch(1 0 0 / 10%)",
-            input: "oklch(1 0 0 / 15%)",
+            "primary-foreground": "oklch(0.985 0 0)",
             ring: "oklch(0.637 0.237 25.331)",
-            "chart-1": "oklch(0.488 0.243 264.376)",
-            "chart-2": "oklch(0.696 0.17 162.48)",
-            "chart-3": "oklch(0.769 0.188 70.08)",
-            "chart-4": "oklch(0.627 0.265 303.9)",
-            "chart-5": "oklch(0.645 0.246 16.439)",
-            sidebar: "oklch(0.21 0.006 285.885)",
-            "sidebar-foreground": "oklch(0.985 0 0)",
             "sidebar-primary": "oklch(0.637 0.237 25.331)",
             "sidebar-primary-foreground": "oklch(0.971 0.013 17.38)",
-            "sidebar-accent": "oklch(0.274 0.006 286.033)",
-            "sidebar-accent-foreground": "oklch(0.985 0 0)",
-            "sidebar-border": "oklch(1 0 0 / 10%)",
             "sidebar-ring": "oklch(0.637 0.237 25.331)"
-          }
+          })
         }
       }
     };

--- a/src/hooks/useWebsiteColors.ts
+++ b/src/hooks/useWebsiteColors.ts
@@ -224,7 +224,7 @@ export default function useWebsiteColors() {
           },
           ".dark": generateDarkTheme({
             primary: "oklch(0.696 0.17 162.48)",
-            "primary-foreground": "oklch(0.985 0 0)",
+            "primary-foreground": "oklch(0.974 0.036 174.767)",
             ring: "oklch(0.527 0.154 150.069)",
             "sidebar-primary": "oklch(0.696 0.17 162.48)",
             "sidebar-primary-foreground": "oklch(0.393 0.095 152.535)",


### PR DESCRIPTION
**What does this PR do?**
Adds `generateDarkTheme ` to create dark themes from a light base using OKLCH.
It parses the primary color, extracts hue and chroma, and generates variants (very dark, dark, medium) to build a consistent dark palette. Fallback values are included for unsupported formats.


**Screenshots or GIFs (if applicable)**
![image](https://github.com/user-attachments/assets/e94419b0-12a7-4ead-bbe0-8d520623194e)
![image](https://github.com/user-attachments/assets/a5aa416b-46b3-4942-8c39-a5f32b0c4662)
![image](https://github.com/user-attachments/assets/47c0318c-780c-489e-abc1-1c5b4ed90541)
![image](https://github.com/user-attachments/assets/7ec13d9e-f179-451f-bf05-caa00e8879fb)
![image](https://github.com/user-attachments/assets/7ebbbeb1-8e37-4d82-a3d8-35f44287d17c)
![image](https://github.com/user-attachments/assets/f24cff13-e8a5-4da0-acfb-da00ec5c9ae4)
![image](https://github.com/user-attachments/assets/472ad627-9b39-4d04-af76-5f178f522bb0)


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
