### PR TITLE
feat: move bg image storage from localStorage to IndexedDB

### DIFF
--- a/src/components/menu-settings/CustomTheme.tsx
+++ b/src/components/menu-settings/CustomTheme.tsx
@@ -6,7 +6,9 @@ import { ImageIcon } from "@radix-ui/react-icons";
 
 export default function CustomTheme() {
   const dataInputRef = useRef<HTMLInputElement>(null);
-  const setBackgroundImage = useBackgroundImageStore((state => state.setBackgroundImage));
+  const setBackgroundImage = useBackgroundImageStore(
+    (state) => state.setBackgroundImage
+  );
   const t = useTranslations("Index");
   const handleImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
     const newBackgroundImage = event.target.files?.[0];
@@ -35,7 +37,7 @@ export default function CustomTheme() {
     // Convert image to string base64
     const base64Image = await readFileAsBase64(newBackgroundImage);
 
-    // Save to local storage
+    // Save to IndexedDB
     setBackgroundImage(base64Image);
   };
 

--- a/src/components/menu-settings/ThemeSelect.tsx
+++ b/src/components/menu-settings/ThemeSelect.tsx
@@ -11,8 +11,8 @@ interface Variation {
 }
 
 export default function ThemeSelect() {
-  const backgroundImage = useBackgroundImageStore((state) => state.backgroundImage);
-  const deleteBackgroundImage = useBackgroundImageStore((state) => state.deleteBackgroundImage);
+  const { backgroundImage, deleteBackgroundImage } = useBackgroundImageStore();
+
   const { setTheme, resolvedTheme } = useTheme();
   const t = useTranslations("Index.Settings-menu");
   const variation: Variation[] = [

--- a/src/models/indexdb/Images.ts
+++ b/src/models/indexdb/Images.ts
@@ -1,0 +1,18 @@
+import { database } from "@/db/indexdb";
+import BoxDB, { BoxData } from "bxd";
+
+const STORE_NAME = "nx-images";
+
+const imagesSchema = {
+  name: {
+    key: true,
+    type: BoxDB.Types.STRING,
+    index: true,
+  },
+  background: BoxDB.Types.STRING,
+} as const;
+
+const Images = database.create(STORE_NAME, imagesSchema);
+
+export type ImagesType = BoxData<typeof imagesSchema>;
+export default Images;

--- a/src/store/BackgroundThemeStore.ts
+++ b/src/store/BackgroundThemeStore.ts
@@ -1,13 +1,39 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
+"use client";
+import { database } from "@/db/indexdb";
+import Images from "@/models/indexdb/Images";
 
-interface BackgroundImage {
+import { create } from "zustand";
+import { persist, PersistStorage } from "zustand/middleware";
+
+interface BackgroundImageState {
   backgroundImage: string | null;
   setBackgroundImage: (imgBase64: string) => void;
   deleteBackgroundImage: () => void;
 }
 
-export const useBackgroundImageStore = create<BackgroundImage>()(
+const storage: PersistStorage<Pick<BackgroundImageState, "backgroundImage">> = {
+  getItem: async (name) => {
+    if (!database.ready) await database.open();
+    const images = await Images.get(name);
+    if (!images.background) return null;
+    return {
+      state: {
+        backgroundImage: images.background,
+      },
+    };
+  },
+  setItem: async (name, value) => {
+    const background = value.state.backgroundImage;
+    if (!background) return await Images.clear();
+    await Images.add({
+      name,
+      background,
+    });
+  },
+  removeItem: async () => await Images.clear(),
+};
+
+export const useBackgroundImageStore = create<BackgroundImageState>()(
   persist(
     (set) => ({
       backgroundImage: null,
@@ -19,7 +45,8 @@ export const useBackgroundImageStore = create<BackgroundImage>()(
       },
     }),
     {
-      name: 'customBackgroundImage',
+      name: "custom-background-image",
+      storage,
     }
   )
 );


### PR DESCRIPTION
**What does this PR do?**
Migrates background image storage from localStorage to IndexedDB using a custom zustand storage adapter. This allows for better handling of high-quality image uploads without hitting localStorage limits.

**Related Issue(s)**
Closes #412

**Changes**
- Replaced localStorage with IndexedDB for background image persistence.
- Implemented a custom zustand storage adapter using BoxDB for structured data handling.

**Screenshots or GIFs (if applicable)**
<img width="1331" height="783" alt="Captura de pantalla 2025-07-21 a la(s) 2 28 19 p m" src="https://github.com/user-attachments/assets/286e7aa9-9f52-444e-9e10-5ff691780e1b" />
<img width="1365" height="1157" alt="Captura de pantalla 2025-07-21 a la(s) 2 29 09 p m" src="https://github.com/user-attachments/assets/0ace1901-e77d-4e0e-95aa-3964472caaff" />


**Additional Comments**
No

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
