### PR TITLE
Refactor API to Remove _id Parameters

### DIFF
--- a/src/app/api/v1/backups/route.ts
+++ b/src/app/api/v1/backups/route.ts
@@ -6,26 +6,26 @@ import { auth } from '@/auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const { _id, data } = await request.json()
-    if (!_id || !data) return NextResponse.json({ error: 'Incorrect params' }, { status: 400 });
+    const { data } = await request.json()
+    if (!data) return NextResponse.json({ error: 'Incorrect params' }, { status: 400 });
     await connectDB();
 
     const session = await auth();
-    if (!session || session.user.id !== _id) {
+    if (!session) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const user = await User.findById(_id);
+    const user = await User.findById(session.user.id);
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 })
     }
 
     const backup = await Backup.findOneAndUpdate(
       {
-        user: _id,
+        user: session.user.id,
       },
       {
-        user: _id,
+        user: session.user.id,
         data: data,
       },
       {

--- a/src/app/api/v1/users/[id]/route.ts
+++ b/src/app/api/v1/users/[id]/route.ts
@@ -1,44 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import connectDB from '@/db/mongodb';
 import User from '@/models/user';
-import { auth } from '@/auth';
-
-export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  try {
-    const userId = (await params).id;
-
-    const session = await auth();
-    if (!session || session.user.id !== userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const body = await request.json();
-
-    if (!userId) {
-      return NextResponse.json({ error: 'ID is required' }, { status: 404 });
-    }
-
-    await connectDB();
-    const user = await User.findById(userId)
-
-    if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
-    }
-
-    const { email, createdAt, updatedAt, __v, ...rest } = body;
-
-    const updatedUser = await User.findOneAndUpdate(
-      { _id: userId },
-      { ...rest },
-      { new: true }
-    );
-
-    return NextResponse.json(updatedUser);
-  } catch (error) {
-    console.error('Error updating user:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-  }
-}
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {

--- a/src/app/settings/account/page.tsx
+++ b/src/app/settings/account/page.tsx
@@ -51,7 +51,7 @@ export default function Page() {
       loader.start();
       const urlImage = await uploadFile(file, `/avatars`, session?.user?.id);
 
-      const response = await fetch(`/api/v1/users/${session?.user?.id}`, {
+      const response = await fetch(`/api/v1/users`, {
         method: 'PATCH',
         body: JSON.stringify({
           image: urlImage.url,

--- a/src/app/settings/account/save/page.tsx
+++ b/src/app/settings/account/save/page.tsx
@@ -27,7 +27,6 @@ export default function Page() {
       const response = await fetch('/api/v1/backups', {
         method: 'POST',
         body: JSON.stringify({
-          _id: session.user.id,
           data: JSON.stringify(cubes),
         }),
       });


### PR DESCRIPTION
This PR refactors the user and backup APIs to eliminate the need for client-provided `_id` parameters by leveraging session-based authentication instead.

**What does this PR do?**
Simplifies the API by removing `_id` parameters from request bodies and URLs, using `session.user.id` for user identification instead. This makes the API cleaner and more consistent by relying on session authentication.

**Related Issue(s)**
- API cleanup and simplification

**Changes**
- **Backend Changes:**
  - Removed `_id` parameter from backup API endpoint (`/api/v1/backups`)
  - Removed PATCH method from `/api/v1/users/[id]/route.ts`
  - Added PATCH method to `/api/v1/users/route.ts` using session-based authentication
- **Frontend Changes:**
  - Updated account page to use `/api/v1/users` instead of `/api/v1/users/[id]`
  - Removed `_id` parameter from backup save requests

**Screenshots or GIFs (if applicable)**
N/A - Backend API changes only

**Additional Comments**
This refactoring improves API consistency by ensuring all user-related operations use session-based identification rather than mixing URL parameters and request body parameters for user identification.

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.