### PR TITLE
feat(timer): display last solve time in ManualMode

### DIFF
--- a/src/components/timer/ManualMode.tsx
+++ b/src/components/timer/ManualMode.tsx
@@ -110,6 +110,11 @@ export default function ManualMode() {
             {t("preview")}: {formatTime(convertToMs(value))}{" "}
           </div>
         ) : null}
+        {lastSolve && (
+          <div className="mt-2 text-center font-mono text-muted-foreground">
+            Last one: {formatTime(lastSolve.time)}
+          </div>
+        )}
       </form>
       {lastSolve && settings.features.quickActionButtons ? (
         <MenuSolveOptions


### PR DESCRIPTION
**What does this PR do?**
Added a new section to show the last solve time in ManualMode. This improves user visibility of their most recent solve, enhancing the overall user experience.


**Related Issue(s)**
#430 

**Changes**
List the changes made in this PR. This could include new features, bug fixes, improvements, or any other modifications.

**Screenshots or GIFs (if applicable)**
<img width="1573" height="928" alt="image" src="https://github.com/user-attachments/assets/83a1dcc6-cc5d-4028-af49-aa2a1ce100a7" />


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
