### PR TITLE
fix: Update profile section message for empty backup state

### DIFF
--- a/src/components/people/empty-tab-content.tsx
+++ b/src/components/people/empty-tab-content.tsx
@@ -18,8 +18,8 @@ export default function EmptyTabContent() {
           opacity: 0.1
         }}
       ></Image>
-      <div className="relative scroll-m-20 text-xl tracking-tight max-w-40 mx-auto text-center">
-        No content available for this tab.
+      <div className="relative scroll-m-20 text-xl tracking-tight max-w-prose md:max-w-xl mx-auto text-center px-4">
+        This account has no backup data to display.
       </div>
     </div>
   );


### PR DESCRIPTION
<img width="2355" height="1482" alt="image" src="https://github.com/user-attachments/assets/5b66a35e-7366-438b-9226-14317490861d" />Clarifies empty-state messaging in the profile backup section by updating the copy shown when a user has no backup data.
Improves UX with a subtle background and centered layout for better readability and visual consistency.