### PR TITLE
Implementation of the ability to self-host NexusTimer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.out
+dist
+.git
+*.log
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# ---- deps ----
+FROM node:20-alpine AS deps
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ---- build ----
+FROM node:20-alpine AS build
+WORKDIR /app
+RUN corepack enable
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+RUN pnpm prune --prod --ignore-scripts
+
+# ---- runtime ----
+FROM node:20-alpine AS runner
+ENV NODE_ENV=production PORT=3000
+WORKDIR /app
+
+# copy compiled app + prod deps
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/node_modules ./node_modules
+
+# run as non-root
+USER node
+EXPOSE 3000
+HEALTHCHECK CMD node -e "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+# start Next's server
+CMD ["node","node_modules/next/dist/bin/next","start","-p","3000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  web:
+    build: .
+    image: nexustimer:latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
**What does this PR do?**
This pull request adds the ability to self-host NexusTimer by running it in a Docker container.

**Related Issue(s)**
None

**Changes**
Added the following files:
- Dockerfile
- .dockerignore
- docker-compose.yml

**Screenshots or GIFs (if applicable)**
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/447dc1cc-3c1b-47af-92cd-ca776b2aad79" />

**Additional Comments**
I originally implemented this for personal use. But I though it'll be a good idea to share it. I could keep my fork instead of merging it to the main repo if you want.

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
