### PR TITLE
feat(sidebar): add quick-action button to create cubes

### DIFF
--- a/src/widgets/sidebar/ui/AppSidebar.tsx
+++ b/src/widgets/sidebar/ui/AppSidebar.tsx
@@ -10,12 +10,14 @@ import {
   HistoryIcon,
   LandPlot,
   MonitorDown,
+  PlusIcon,
   ReplaceIcon,
   Settings,
   TableProperties,
   TimerIcon,
   UsersRound
 } from 'lucide-react'
+import { useCubeActions } from '@/features/manage-cubes/model/useCubeActions'
 
 import {
   Sidebar,
@@ -43,6 +45,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { open, openMobile, setOpenMobile, isMobile } = useSidebar()
   const t = useTranslations('Index')
   const { isInstallable, install } = usePwaInstall()
+  const { handleCreate } = useCubeActions()
 
   const data = useMemo(
     () => ({
@@ -65,7 +68,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         {
           title: t('NavMain.cubes'),
           url: '/cubes',
-          icon: BoxesIcon
+          icon: BoxesIcon,
+          action: {
+            icon: PlusIcon,
+            label: t('CubesPage.new-collection'),
+            onClick: handleCreate
+          }
         },
         {
           title: t('NavMain.transfer'),
@@ -117,7 +125,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         }
       ]
     }),
-    [t]
+    [t, handleCreate]
   )
 
   return (

--- a/src/widgets/sidebar/ui/nav-main.tsx
+++ b/src/widgets/sidebar/ui/nav-main.tsx
@@ -29,6 +29,11 @@ export function NavMain({
     url: string
     icon: LucideIcon
     isActive?: boolean
+    action?: {
+      icon: LucideIcon
+      label: string
+      onClick: () => void
+    }
     items?: {
       title: string
       url: string
@@ -80,6 +85,19 @@ export function NavMain({
                     <span>{item.title}</span>
                   </Link>
                 </SidebarMenuButton>
+                {item.action && !item.items?.length ? (
+                  <SidebarMenuAction
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      item.action!.onClick()
+                      if (isMobile) setOpenMobile(false)
+                    }}
+                  >
+                    <item.action.icon />
+                    <span className="sr-only">{item.action.label}</span>
+                  </SidebarMenuAction>
+                ) : null}
                 {item.items?.length ? (
                   <>
                     <CollapsibleTrigger asChild>


### PR DESCRIPTION
**What does this PR do?**
Introduces a new + action button in the Cubes sidebar item that directly opens the Create Collection modal, eliminating the need to navigate to /cubes first. 


https://github.com/user-attachments/assets/87228ad0-52cf-46bd-b85d-eab3a980f3d6


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
