### PR TITLE
feat(trainer): add cube preview toggle and algorithms modal

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -628,7 +628,13 @@
         "markedAsLearned": "Marked as learned",
         "markAsLearned": "Mark as learned",
         "skip": "Skip",
-        "history": "History"
+        "history": "History",
+        "showSolveInfo": "Show solve info",
+        "hideSolveInfo": "Hide solve info",
+        "viewAlgorithms": "View algorithms"
+      },
+      "algorithmsModal": {
+        "title": "Algorithms"
       },
       "editTargetModal": {
         "title": "Edit target time",

--- a/src/features/trainer/model/useTrainerPrefsStore.ts
+++ b/src/features/trainer/model/useTrainerPrefsStore.ts
@@ -1,0 +1,19 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface TrainerPrefsState {
+  showSolveInfo: boolean
+  toggleShowSolveInfo: () => void
+}
+
+export const useTrainerPrefsStore = create<TrainerPrefsState>()(
+  persist(
+    (set) => ({
+      showSolveInfo: true,
+      toggleShowSolveInfo: () => set((s) => ({ showSolveInfo: !s.showSolveInfo }))
+    }),
+    { name: 'trainer-prefs' }
+  )
+)

--- a/src/features/trainer/ui/TrainerAlgorithmsModal.tsx
+++ b/src/features/trainer/ui/TrainerAlgorithmsModal.tsx
@@ -5,14 +5,11 @@ import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog
 import { useOverlayStore } from '@/shared/model/overlay-store/useOverlayStore'
 import type { Alg } from '@/features/algorithms-list/model/types'
 
-interface TrainerAlgorithmsModalProps {
-  caseName: string
-  algs: Alg[]
-}
-
-export default function TrainerAlgorithmsModal({ caseName, algs }: TrainerAlgorithmsModalProps) {
+export default function TrainerAlgorithmsModal() {
   const t = useTranslations('Index.TrainerPage.algorithmsModal')
-  useOverlayStore()
+  const metadata = useOverlayStore((s) => s.activeOverlay?.metadata)
+  const caseName = metadata?.caseName as string | undefined
+  const algs = (metadata?.algs ?? []) as Alg[]
 
   return (
     <DialogContent className="sm:max-w-md">

--- a/src/features/trainer/ui/TrainerAlgorithmsModal.tsx
+++ b/src/features/trainer/ui/TrainerAlgorithmsModal.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useOverlayStore } from '@/shared/model/overlay-store/useOverlayStore'
+import type { Alg } from '@/features/algorithms-list/model/types'
+
+interface TrainerAlgorithmsModalProps {
+  caseName: string
+  algs: Alg[]
+}
+
+export default function TrainerAlgorithmsModal({ caseName, algs }: TrainerAlgorithmsModalProps) {
+  const t = useTranslations('Index.TrainerPage.algorithmsModal')
+  useOverlayStore()
+
+  return (
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>
+          {t('title')} — {caseName}
+        </DialogTitle>
+      </DialogHeader>
+
+      <ol className="flex flex-col gap-2">
+        {algs.map((alg, i) => (
+          <li key={alg.id} className="flex items-start gap-3 rounded-md border bg-muted/40 px-3 py-2">
+            <span className="text-[11px] font-mono tabular-nums text-muted-foreground pt-0.5 shrink-0 w-4">
+              {i + 1}.
+            </span>
+            <div className="flex flex-col gap-0.5 min-w-0">
+              {alg.label && (
+                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{alg.label}</span>
+              )}
+              <code className="text-sm font-mono break-all">{alg.moves}</code>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </DialogContent>
+  )
+}

--- a/src/features/trainer/ui/TrainerCurrentCase.tsx
+++ b/src/features/trainer/ui/TrainerCurrentCase.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { SkipForward, BookmarkCheck, Bookmark, History, Target, ListChecks } from 'lucide-react'
+import { SkipForward, BookmarkCheck, Bookmark, History, Target, ListChecks, Eye, EyeOff, BookOpen } from 'lucide-react'
 import AlgorithmRender from '@/shared/ui/twisty/AlgorithmRender'
 import { TwistyPlayer } from 'cubing/twisty'
 import { cn } from '@/shared/lib/utils'
@@ -27,6 +27,9 @@ interface TrainerCurrentCaseProps {
   pickedCount?: number
   totalCount?: number
   onPickCases?: () => void
+  showSolveInfo?: boolean
+  onToggleSolveInfo?: () => void
+  onViewAlgorithms?: () => void
 }
 
 export default function TrainerCurrentCase({
@@ -48,7 +51,10 @@ export default function TrainerCurrentCase({
   onEditTarget,
   pickedCount,
   totalCount,
-  onPickCases
+  onPickCases,
+  showSolveInfo = true,
+  onToggleSolveInfo,
+  onViewAlgorithms
 }: TrainerCurrentCaseProps) {
   const t = useTranslations('Index.TrainerPage')
   return (
@@ -92,6 +98,30 @@ export default function TrainerCurrentCase({
           </Button>
         )}
         <div className="ml-auto flex items-center gap-1.5">
+          {onViewAlgorithms && (
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onViewAlgorithms}
+              aria-label={t('actions.viewAlgorithms')}
+              title={t('actions.viewAlgorithms')}
+            >
+              <BookOpen className="h-4 w-4" />
+            </Button>
+          )}
+          {onToggleSolveInfo && (
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onToggleSolveInfo}
+              aria-label={showSolveInfo ? t('actions.hideSolveInfo') : t('actions.showSolveInfo')}
+              title={showSolveInfo ? t('actions.hideSolveInfo') : t('actions.showSolveInfo')}
+            >
+              {showSolveInfo ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </Button>
+          )}
           <Button
             variant={isLearned ? 'default' : 'outline'}
             size="icon"
@@ -136,26 +166,28 @@ export default function TrainerCurrentCase({
       )}
 
       <div className="flex flex-row items-center gap-3 sm:gap-4">
-        <div
-          className="shrink-0 rounded-md border bg-muted/40 p-1 sm:p-2 flex items-center justify-center relative overflow-hidden"
-          style={{
-            backgroundImage:
-              'repeating-linear-gradient(45deg, color-mix(in oklab, currentColor 8%, transparent) 0 6px, transparent 6px 14px)'
-          }}
-        >
-          {vizConfig ? (
-            <>
-              <span className="sm:hidden">
-                <AlgorithmRender config={vizConfig} width={56} height={56} />
-              </span>
-              <span className="hidden sm:inline-flex">
-                <AlgorithmRender config={vizConfig} width={96} height={96} />
-              </span>
-            </>
-          ) : (
-            <div className="size-14 sm:size-24 rounded-md bg-muted" />
-          )}
-        </div>
+        {showSolveInfo && (
+          <div
+            className="shrink-0 rounded-md border bg-muted/40 p-1 sm:p-2 flex items-center justify-center relative overflow-hidden"
+            style={{
+              backgroundImage:
+                'repeating-linear-gradient(45deg, color-mix(in oklab, currentColor 8%, transparent) 0 6px, transparent 6px 14px)'
+            }}
+          >
+            {vizConfig ? (
+              <>
+                <span className="sm:hidden">
+                  <AlgorithmRender config={vizConfig} width={56} height={56} />
+                </span>
+                <span className="hidden sm:inline-flex">
+                  <AlgorithmRender config={vizConfig} width={96} height={96} />
+                </span>
+              </>
+            ) : (
+              <div className="size-14 sm:size-24 rounded-md bg-muted" />
+            )}
+          </div>
+        )}
 
         <div className="flex flex-1 min-w-0 items-center justify-center">
           <div

--- a/src/features/trainer/ui/TrainerExperience.tsx
+++ b/src/features/trainer/ui/TrainerExperience.tsx
@@ -165,7 +165,8 @@ export default function TrainerExperience() {
     if (!currentCase) return
     open({
       id: 'trainer-algorithms',
-      component: <TrainerAlgorithmsModal caseName={currentCase.name} algs={currentCase.algs} />
+      metadata: { caseName: currentCase.name, algs: currentCase.algs },
+      component: <TrainerAlgorithmsModal />
     })
   }
 

--- a/src/features/trainer/ui/TrainerExperience.tsx
+++ b/src/features/trainer/ui/TrainerExperience.tsx
@@ -10,8 +10,10 @@ import TrainerCurrentCase from '@/features/trainer/ui/TrainerCurrentCase'
 import TrainerMethodSelect from '@/features/trainer/ui/TrainerMethodSelect'
 import TrainerEditTargetModal from '@/features/trainer/ui/TrainerEditTargetModal'
 import TrainerPickCasesModal from '@/features/trainer/ui/TrainerPickCasesModal'
+import TrainerAlgorithmsModal from '@/features/trainer/ui/TrainerAlgorithmsModal'
 import TrainerRotationModeChips from '@/features/trainer/ui/TrainerRotationModeChips'
 import { useTrainerLearned } from '@/features/trainer/model/useTrainerLearned'
+import { useTrainerPrefsStore } from '@/features/trainer/model/useTrainerPrefsStore'
 import { setTrainerLearned } from '@/features/trainer/model/mutateTrainerLearned'
 import { useOverlayStore } from '@/shared/model/overlay-store/useOverlayStore'
 import { TwistyPlayer } from 'cubing/twisty'
@@ -61,6 +63,8 @@ export default function TrainerExperience() {
   const isAuthed = !!session?.user?.id
 
   const { open } = useOverlayStore()
+  const showSolveInfo = useTrainerPrefsStore((s) => s.showSolveInfo)
+  const toggleShowSolveInfo = useTrainerPrefsStore((s) => s.toggleShowSolveInfo)
 
   const currentStats = currentCase ? caseStats[currentCase.id] : undefined
 
@@ -154,6 +158,14 @@ export default function TrainerExperience() {
     open({
       id: 'trainer-edit-target',
       component: <TrainerEditTargetModal initial={targetSeconds} onApply={handleApplyTarget} />
+    })
+  }
+
+  const handleOpenAlgorithms = () => {
+    if (!currentCase) return
+    open({
+      id: 'trainer-algorithms',
+      component: <TrainerAlgorithmsModal caseName={currentCase.name} algs={currentCase.algs} />
     })
   }
 
@@ -285,6 +297,9 @@ export default function TrainerExperience() {
               pickedCount={totalCases}
               totalCount={totalSetCases}
               onPickCases={handleOpenPickCases}
+              showSolveInfo={showSolveInfo}
+              onToggleSolveInfo={toggleShowSolveInfo}
+              onViewAlgorithms={currentCase ? handleOpenAlgorithms : undefined}
             />
 
             <div className="lg:hidden mt-auto pt-2">


### PR DESCRIPTION
What does this PR do? 
Adds two new interactive controls to the Trainer page: a toggle to show/hide the cube visualization (useful for blind practice or self-testing) and a button to open a modal listing all algorithms that solve the current case. The show/hide preference is persisted in localStorage so it survives page reloads.

Screenshots or GIFs (if applicable)

https://github.com/user-attachments/assets/fba87820-f084-4ffb-a36b-ab3022c4c3e0


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
