### PR TITLE
fix(backup): support modern csTimer export format missing sessionN

### DIFF
--- a/src/features/manage-backup/lib/importDataFromFile.ts
+++ b/src/features/manage-backup/lib/importDataFromFile.ts
@@ -53,11 +53,7 @@ const nxTimerSchema = z.array(
 )
 
 const csTimerSchema = z.object({
-  properties: z
-    .object({
-      sessionN: z.number()
-    })
-    .passthrough()
+  properties: z.object({}).passthrough()
 })
 
 const cubeDeskSchema = z.object({


### PR DESCRIPTION
Summary
- csTimer backups exported with newer versions use `properties.session` instead of `properties.sessionN`
- The old schema validation required `sessionN` as a required field, causing all modern csTimer imports to fail with "No valid data found in the backup file."
- Simplified the `csTimerSchema` to only require a `properties` object, which is the real identifier of the csTimer format



