### PR TITLE
feat(log): add log entity and capture auth sign-in errors

### DIFF
--- a/src/entities/log/model/log.ts
+++ b/src/entities/log/model/log.ts
@@ -1,0 +1,34 @@
+import { Schema, models, model } from 'mongoose'
+
+export enum LogType {
+  AuthError = 'auth_error',
+  ApiError = 'api_error',
+  Info = 'info',
+  Warning = 'warning'
+}
+
+export interface LogDocument {
+  _id: string
+  type: LogType
+  message: string
+  metadata?: Record<string, unknown>
+  createdAt: Date
+}
+
+const LogSchema = new Schema(
+  {
+    type: {
+      type: String,
+      enum: Object.values(LogType),
+      required: true
+    },
+    message: { type: String, required: true },
+    metadata: { type: Schema.Types.Mixed }
+  },
+  { timestamps: true, capped: { size: 5 * 1024 * 1024, max: 1000 } }
+)
+
+LogSchema.index({ createdAt: -1 })
+LogSchema.index({ type: 1 })
+
+export default models.Log || model('Log', LogSchema)

--- a/src/shared/config/auth/auth.ts
+++ b/src/shared/config/auth/auth.ts
@@ -3,6 +3,7 @@ import Google from 'next-auth/providers/google'
 import Discord from 'next-auth/providers/discord'
 import connectDB from '@/shared/config/mongodb/mongodb'
 import User from '@/entities/user/model/user'
+import Log, { LogType } from '@/entities/log/model/log'
 
 declare module 'next-auth' {
   /**
@@ -77,7 +78,19 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         user.email = dbUser.email
         return true
       } catch (error) {
-        console.error('Error in signIn:', error)
+        try {
+          await Log.create({
+            type: LogType.AuthError,
+            message: error instanceof Error ? error.message : String(error),
+            metadata: {
+              provider: account?.provider ?? 'unknown',
+              email: user?.email ?? null,
+              stack: error instanceof Error ? error.stack : undefined
+            }
+          })
+        } catch {
+          console.error('Failed to write log:', error)
+        }
         return false
       }
     }

--- a/src/shared/config/mongodb/mongodb.ts
+++ b/src/shared/config/mongodb/mongodb.ts
@@ -7,6 +7,7 @@ import '../../../entities/solve/model/solve'
 import '../../../entities/backup/model/backup'
 import '../../../entities/trainer-solve/model/trainer-solve'
 import '../../../entities/trainer-stats/model/trainer-stats'
+import '../../../entities/log/model/log'
 
 const connectDB = async () => {
   if (mongoose.connections[0].readyState === 1) {


### PR DESCRIPTION
**What does this PR do?**
  - Adds a generic `Log` entity with `type`, `message`, and `metadata` fields to centralize server-side logging
  - The `signIn` callback in NextAuth now persists any caught error as an `auth_error` log instead of silently swallowing it, including provider, email, and stack trace in
  `metadata`

**Related Issue(s)**
#550

**Additional Comments**
Experimental

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
