### PR TITLE
fix: localize stats date-range labels

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -198,6 +198,16 @@
       "sessions-tooltip": "Counts only session solves for every cube in the same category.",
       "cube-all-tooltip": "Combines all historical and session solves for only the selected cube.",
       "cube-session-tooltip": "Counts only session solves for only the selected cube.",
+      "date-range": {
+        "all-time": "All Time",
+        "today": "Today",
+        "this-week": "This Week",
+        "last-week": "Last 7 days",
+        "this-month": "This Month",
+        "last-month": "Last 30 days",
+        "this-year": "This Year",
+        "last-year": "Last 365 days"
+      },
       "empty-statistics": "No Statistics Available",
       "empty-statistics-description": "It looks like your solve vault is currently empty."
     },

--- a/src/features/date-range-select/model/useDateRangeSelect.ts
+++ b/src/features/date-range-select/model/useDateRangeSelect.ts
@@ -1,22 +1,23 @@
 import { useQueryState } from 'nuqs'
+import { useTranslations } from 'next-intl'
 import { STATES } from '@/shared/const/states'
 import { DateRange } from '@/shared/types/enums'
 
 export default function useDateRangeSelect() {
+  const t = useTranslations('Index.StatsPage.date-range')
   const [dateRange, setDateRange] = useQueryState(STATES.STATISTICS_PAGE.DATE_RANGE.KEY, {
     defaultValue: STATES.STATISTICS_PAGE.DATE_RANGE.DEFAULT_VALUE
   })
 
-  // TODO: Add translations from here useTranslation hook, to extract properly
   const DATE_RANGE_LABELS: Record<DateRange, string> = {
-    [DateRange.ALL_TIME]: 'All Time',
-    [DateRange.TODAY]: 'Today',
-    [DateRange.THIS_WEEK]: 'This Week',
-    [DateRange.LAST_WEEK]: 'Last 7 days',
-    [DateRange.THIS_MONTH]: 'This Month',
-    [DateRange.LAST_MONTH]: 'Last 30 days',
-    [DateRange.THIS_YEAR]: 'This Year',
-    [DateRange.LAST_YEAR]: 'Last 365 days'
+    [DateRange.ALL_TIME]: t('all-time'),
+    [DateRange.TODAY]: t('today'),
+    [DateRange.THIS_WEEK]: t('this-week'),
+    [DateRange.LAST_WEEK]: t('last-week'),
+    [DateRange.THIS_MONTH]: t('this-month'),
+    [DateRange.LAST_MONTH]: t('last-month'),
+    [DateRange.THIS_YEAR]: t('this-year'),
+    [DateRange.LAST_YEAR]: t('last-year')
   }
 
   return { dateRange, setDateRange, DATE_RANGE_LABELS }


### PR DESCRIPTION
## Summary
- move the stats date-range labels into `messages/en.json`
- read the date-range labels through `next-intl` in `useDateRangeSelect`
- keep other locales on the existing English fallback path until translated keys are added

Closes #563.

## Validation
- `node -e 'JSON.parse(require("fs").readFileSync("messages/en.json","utf8")); console.log("json ok")'`
- `./node_modules/.bin/prettier --check src/features/date-range-select/model/useDateRangeSelect.ts messages/en.json`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/next build --webpack`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

## Notes
- I only added English keys, matching the maintainer note in #563.
- `pnpm run lint` did not run on my machine because local `pnpm` 11 stops before scripts with dependency build-script approval required. Direct `next lint` is not available in this Next 16 CLI.
- The direct production build exited 0; it printed an existing Firebase URL warning during static page generation.