### PR TITLE
feat: render last-layer algorithms on the yellow (D) layer

### DIFF
--- a/src/app/(with-sidebar)/algorithms/page.tsx
+++ b/src/app/(with-sidebar)/algorithms/page.tsx
@@ -23,8 +23,8 @@ export default function AlgorithmsMethodsPage() {
       <PageBody variant="hero" className="px-4 pb-4 md:px-8 md:pb-8 lg:px-12 lg:pb-12">
         {/* Hero section */}
         <div className="mb-8 pb-8">
-          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
-            <div className="max-w-2xl">
+          <div className="flex flex-col gap-6 lg:flex-row md:items-end md:justify-between">
+            <div className="max-w-2xl me-auto">
               <div className="mb-4 inline-flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1 text-xs font-medium text-muted-foreground">
                 <BookOpen className="h-3.5 w-3.5" />
                 {t('title')}

--- a/src/features/algorithms-list/ui/algorithm-card.tsx
+++ b/src/features/algorithms-list/ui/algorithm-card.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { cn } from '@/shared/lib/utils'
 import { useOverlayStore } from '@/shared/model/overlay-store/useOverlayStore'
 import AlgorithmRender from '@/shared/ui/twisty/AlgorithmRender'
+import { applyYellowOrientation } from '@/shared/lib/algorithms/vizConfig'
 import AlgorithmModal from '@/features/algorithms-list/ui/algorithm-modal'
 import ActionButton from '@/features/algorithms-list/ui/action-button'
 import AlternativeRow from '@/features/algorithms-list/ui/alternative-row'
@@ -35,16 +36,18 @@ export default function AlgorithmCard({
   const [primary, ...alternatives] = algorithm.algs
   const canExpand = alternatives.length > 0
 
-  const vizConfig = _.merge(
-    {
-      visualization: 'experimental-2D-LL',
-      background: 'none',
-      controlPanel: 'none',
-      alg: primary?.moves,
-      experimentalStickering: 'OLL',
-      experimentalSetupAnchor: 'end'
-    },
-    virtualization
+  const vizConfig = applyYellowOrientation(
+    _.merge(
+      {
+        visualization: 'experimental-2D-LL',
+        background: 'none',
+        controlPanel: 'none',
+        alg: primary?.moves,
+        experimentalStickering: 'OLL',
+        experimentalSetupAnchor: 'end'
+      },
+      virtualization
+    )
   )
 
   const openPreview = (alg: string) => {

--- a/src/features/algorithms-list/ui/algorithm-modal.tsx
+++ b/src/features/algorithms-list/ui/algorithm-modal.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { TwistyPlayer } from 'cubing/twisty'
 import { useOverlayStore } from '@/shared/model/overlay-store/useOverlayStore'
 import AlgorithmRender from '@/shared/ui/twisty/AlgorithmRender'
+import { applyYellowOrientation } from '@/shared/lib/algorithms/vizConfig'
 import { Badge } from '@/components/ui/badge'
 
 export default function AlgorithmModal() {
@@ -21,14 +22,13 @@ export default function AlgorithmModal() {
       <div className="rounded-xl bg-muted/30 p-3 size-fit flex items-center justify-center w-full aspect-square max-w-[300px]">
         <AlgorithmRender
           config={
-            {
+            applyYellowOrientation({
               alg: activeOverlay?.metadata?.alg || '',
-              experimentalDragInput: 'none',
               tempoScale: 1,
               experimentalSetupAnchor: 'end',
               puzzle: activeOverlay?.metadata?.cube || '3x3',
               background: 'none'
-            } as unknown as TwistyPlayer
+            }) as unknown as TwistyPlayer
           }
           width={300}
           height={300}

--- a/src/features/trainer/lib/trainerUtils.ts
+++ b/src/features/trainer/lib/trainerUtils.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { Alg } from 'cubing/alg'
 import type { TwistyPlayer } from 'cubing/twisty'
 import type { TrainerPenalty } from '@/entities/trainer-solve/model/constants'
+import { applyYellowOrientation } from '@/shared/lib/algorithms/vizConfig'
 
 export const formatMs = (ms: number): string => (ms / 1000).toFixed(2)
 
@@ -72,4 +73,6 @@ export const buildVizConfig = (
   algMoves: string,
   overrides?: Record<string, unknown>
 ): Partial<TwistyPlayer> =>
-  _.merge({}, VIZ_BASE, overrides ?? {}, { puzzle, alg: algMoves }) as unknown as Partial<TwistyPlayer>
+  applyYellowOrientation(
+    _.merge({}, VIZ_BASE, overrides ?? {}, { puzzle, alg: algMoves })
+  ) as unknown as Partial<TwistyPlayer>

--- a/src/shared/lib/algorithms/vizConfig.ts
+++ b/src/shared/lib/algorithms/vizConfig.ts
@@ -1,0 +1,47 @@
+import _ from 'lodash'
+import type { TwistyPlayer } from 'cubing/twisty'
+
+/**
+ * cubing.js hardcodes its built-in OLL/PLL stickerings to the white (U) layer,
+ * so last-layer cases always render with a white top. To show them on the
+ * conventional yellow (D) layer instead, we override the stickering with a mask
+ * on the D-layer orbits and rotate the puzzle with `z2` so yellow faces up.
+ * `full`-stickered cubes need no mask (the whole cube is shown) — just `z2`.
+ *
+ * Mask codes (see cubing.js parseSerializedStickeringMask): D = Dim,
+ * O = IgnoreNonPrimary (OLL), P = PermuteNonPrimary (PLL), - = Regular. The
+ * D-layer pieces sit at slots 4–7 of EDGES/CORNERS and slot 5 of CENTERS, so
+ * each entry mirrors the built-in U-layer stickering onto those D-layer slots.
+ */
+const D_LAYER_MASKS: Record<string, Record<string, string>> = {
+  OLL: {
+    '2x2x2': 'CORNERS:DDDDOOOO',
+    '3x3x3': 'EDGES:DDDDOOOODDDD,CORNERS:DDDDOOOO,CENTERS:DDDDD-'
+  },
+  PLL: {
+    '3x3x3': 'EDGES:DDDDPPPPDDDD,CORNERS:DDDDPPPP,CENTERS:DDDDDD'
+  }
+}
+
+const SUPPORTED_PUZZLES = new Set(['2x2x2', '3x3x3', '4x4x4', '5x5x5'])
+
+type LooseViz = Partial<TwistyPlayer> & { experimentalStickering?: string; puzzle?: string }
+
+const normalizePuzzle = (puzzle: string): string => (puzzle === '2x2' ? '2x2x2' : puzzle === '3x3' ? '3x3x3' : puzzle)
+
+/**
+ * Orients 2x2–5x5 algorithm cases on the yellow (D) layer instead of the default
+ * white (U) layer. 4x4/5x5 sets use `full` stickering, so they only get the `z2`
+ * rotation (no mask). Unsupported puzzles are returned unchanged.
+ */
+export const applyYellowOrientation = <T extends object>(config: T): T => {
+  const viz = config as LooseViz
+  const puzzle = normalizePuzzle(viz.puzzle ?? '3x3x3')
+  if (!SUPPORTED_PUZZLES.has(puzzle)) return config
+
+  const mask = D_LAYER_MASKS[viz.experimentalStickering ?? '']?.[puzzle]
+  const patch: Record<string, string> = { experimentalSetupAlg: 'z2' }
+  if (mask) patch.experimentalStickeringMaskOrbits = mask
+
+  return _.merge({}, config, patch) as T
+}


### PR DESCRIPTION
**What does this PR do?**
  Introduces a shared `applyYellowOrientation` helper that flips visualizations to the conventional
  yellow (D) layer and wires it into every algorithm visualization surface.


**Related Issue(s)**
#551 

**Screenshots or GIFs (if applicable)**
<img width="1589" height="1222" alt="image" src="https://github.com/user-attachments/assets/e40fd87f-7409-415b-87f1-a7dff00faa87" />
<img width="1586" height="1046" alt="image" src="https://github.com/user-attachments/assets/a9cda9b5-62e3-4dff-9421-6dc31f64c981" />

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
