### PR TITLE
feat: store backups as plain JSON instead of gzipped .txt

### DIFF
--- a/src/app/api/v1/backups/route.ts
+++ b/src/app/api/v1/backups/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
     const key = newBackupKey(userId, updatedAt)
 
     await files.upload(key, blob, {
-      contentType: 'application/octet-stream',
+      contentType: 'application/json',
       cacheControl: 'public, max-age=31536000, immutable'
     })
 

--- a/src/entities/backup/model/backup-storage.ts
+++ b/src/entities/backup/model/backup-storage.ts
@@ -25,7 +25,7 @@ const compactIso = (timestamp: number) =>
 
 /** Build the key for a brand-new backup created at `timestamp`. */
 export const newBackupKey = (userId: string, timestamp: number): string =>
-  backupKey(userId, `${compactIso(timestamp)}.txt`)
+  backupKey(userId, `${compactIso(timestamp)}.json`)
 
 /** Parse the compact ISO stamp a backup name encodes back to ms. */
 const parseCompactIso = (name: string): number | null => {

--- a/src/entities/backup/model/useBackup.ts
+++ b/src/entities/backup/model/useBackup.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { decompressSync, strFromU8 } from 'fflate'
 import { Cube } from '@/entities/cube/model/types'
 import { normalizeOldData, preventDuplicateDeleteStatus } from '@/features/manage-backup/lib/importDataFromFile'
 
@@ -20,11 +19,7 @@ export const useBackup = (url: string | undefined) => {
         const response = await fetch(url)
         if (!response.ok) throw new Error('Network response was not ok')
 
-        const compressed = new Uint8Array(await response.arrayBuffer())
-        const decompressed = decompressSync(compressed)
-        const data = strFromU8(decompressed)
-
-        setBackup(preventDuplicateDeleteStatus(normalizeOldData(JSON.parse(data))))
+        setBackup(preventDuplicateDeleteStatus(normalizeOldData(await response.json())))
       } catch {
         setBackup([])
       } finally {

--- a/src/features/compare-users/model/useUserBackups.ts
+++ b/src/features/compare-users/model/useUserBackups.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import _ from 'lodash'
-import { decompressSync, strFromU8 } from 'fflate'
 import { Cube } from '@/entities/cube/model/types'
 
 interface User {
@@ -23,10 +22,7 @@ export function useUserBackups(users: User[]) {
             if (user.backup?.url) {
               const response = await fetch(user.backup.url)
               if (!response.ok) throw new Error('Network response was not ok')
-              const compressed = new Uint8Array(await response.arrayBuffer())
-              const decompressed = decompressSync(compressed)
-              const data = strFromU8(decompressed)
-              const cubeData = JSON.parse(data) as Cube[]
+              const cubeData = (await response.json()) as Cube[]
               const merged = _.groupBy(cubeData, 'category')
               return [user._id, merged] as const
             }

--- a/src/features/manage-backup/ui/ImportBackupInline.tsx
+++ b/src/features/manage-backup/ui/ImportBackupInline.tsx
@@ -79,7 +79,7 @@ export default function ImportBackupInline() {
         <Dropzone
           onDrop={handleImportBackup}
           onError={console.error}
-          accept={{ 'application/txt': ['.txt'] }}
+          accept={{ 'application/json': ['.json'], 'text/plain': ['.txt'] }}
           className="min-h-35"
           data-testid="import-backup-dropzone"
         >

--- a/src/features/manage-backups/model/useApplyBackup.ts
+++ b/src/features/manage-backups/model/useApplyBackup.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { toast } from 'sonner'
-import { decompressSync, strFromU8 } from 'fflate'
 import {
   importNexusTimerData,
   normalizeOldData,
@@ -33,8 +32,7 @@ export function useApplyBackup() {
       const res = await fetch(backup.url)
       if (!res.ok) throw new Error(`Fetch failed with status ${res.status}`)
 
-      const compressed = new Uint8Array(await res.arrayBuffer())
-      const data = strFromU8(decompressSync(compressed))
+      const data = await res.text()
       const cubes = preventDuplicateDeleteStatus(normalizeOldData(importNexusTimerData(data)))
 
       await cubesDB.clear()

--- a/src/features/settings/lib/exportDataToFile.ts
+++ b/src/features/settings/lib/exportDataToFile.ts
@@ -1,7 +1,7 @@
 import { Cube } from '@/entities/cube/model/types'
 import dayjs from '@/shared/lib/dayjs'
 
-const OUTPUT_FILE_NAME = `Backup-NT-${dayjs().format('YYYY-MM-DD HH:mm:ss')}.txt`
+const OUTPUT_FILE_NAME = `Backup-NT-${dayjs().format('YYYY-MM-DD HH:mm:ss')}.json`
 
 /**
  * Exports the cube data to a JSON file and initiates a download.
@@ -24,7 +24,7 @@ export default async function exportDataToFile(cubes: Cube[]): Promise<void> {
    * Create a Blob with the stringified cubes.
    * @type {Blob}
    */
-  const blob = new Blob([stringifiedCubes], { type: 'text/plain' })
+  const blob = new Blob([stringifiedCubes], { type: 'application/json' })
 
   /**
    * Create a URL for the Blob.

--- a/src/shared/lib/backup/uploadWithProgress.ts
+++ b/src/shared/lib/backup/uploadWithProgress.ts
@@ -8,7 +8,7 @@ export const uploadWithProgress = (
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
     xhr.open('POST', url)
-    xhr.setRequestHeader('Content-Type', 'application/octet-stream')
+    xhr.setRequestHeader('Content-Type', blob.type || 'application/octet-stream')
     xhr.timeout = UPLOAD_TIMEOUT_MS
 
     xhr.upload.onprogress = (event) => {

--- a/src/shared/model/backup/useSyncBackup.ts
+++ b/src/shared/model/backup/useSyncBackup.ts
@@ -1,6 +1,5 @@
 import { importNexusTimerData, normalizeOldData } from '@/features/manage-backup/lib/importDataFromFile'
 import { toast } from 'sonner'
-import { compressSync, decompressSync, strFromU8, strToU8 } from 'fflate'
 import { useSession } from 'next-auth/react'
 import { useTimerStore } from '@/shared/model/timer/useTimerStore'
 import { useState } from 'react'
@@ -39,8 +38,7 @@ export const useSyncBackup = () => {
 
     const text = JSON.stringify(cubes)
 
-    const compressed = compressSync(strToU8(text))
-    const blob = new Blob([compressed], { type: 'application/octet-stream' })
+    const blob = new Blob([text], { type: 'application/json' })
 
     try {
       const res = await uploadWithProgress('/api/v1/backups', blob, (percent) => {
@@ -83,10 +81,7 @@ export const useSyncBackup = () => {
       }
 
       const doc = await fetch(`${user.backup.url}`)
-      const compressed = new Uint8Array(await doc.arrayBuffer())
-
-      const decompressed = decompressSync(compressed)
-      const data = strFromU8(decompressed)
+      const data = await doc.text()
 
       const backupData = importNexusTimerData(data)
       const existingCubes = await cubesDB.getAllDatabase()


### PR DESCRIPTION
**What does this PR do?**
Backups are now uploaded and read as uncompressed .json (prep for datalake queries over the bucket).

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
