### PR TITLE
refactor(cube-state-engine): adopt v1.9.0 typings and drop deprecated fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "country-flag-icons": "^1.5.18",
     "cstimer_module": "^0.1.5",
     "cube-solver": "^2.4.1",
-    "cube-state-engine": "^1.8.0",
+    "cube-state-engine": "^1.9.0",
     "cubing": "^0.56.0",
     "dayjs": "^1.11.21",
     "es-toolkit": "^1.42.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
       cube-state-engine:
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.9.0
+        version: 1.9.0
       cubing:
         specifier: ^0.56.0
         version: 0.56.0
@@ -3268,8 +3268,8 @@ packages:
   cube-solver@2.4.1:
     resolution: {integrity: sha512-dDaCE0F4y3VTnh/vzvjV5Li154zLQQJ8tVUKEsWvy8g3Fuq4hf3Z0+cNlBiFq6hhrXNHJ6+deRJwQBV2oUzkDg==}
 
-  cube-state-engine@1.8.0:
-    resolution: {integrity: sha512-ysx5Jnk6QSllNZ4rSJm0ds2gTVW4XM//BmgWdJAexfali31ECzAcR3UvujGrAbcLXZEEOCq7fnsDsCXLbWBiNg==}
+  cube-state-engine@1.9.0:
+    resolution: {integrity: sha512-eQVdq7M9x2LczNz5hR0ynabIBBg+EDYuieZrsbPSfxIm7tiXhY07AZN8lAyZNIoHZKnIUzBo4Xdqh0vNN2DxNA==}
 
   cubing@0.56.0:
     resolution: {integrity: sha512-8CabQLEkWA2iCy4LeyCPN5fCUnfjmz3QJ/Zo6EInEdPX/X/QNHbLhjljfumNHFoM234davupDj/i6D+ml7wAVQ==}
@@ -8891,7 +8891,7 @@ snapshots:
 
   cube-solver@2.4.1: {}
 
-  cube-state-engine@1.8.0: {}
+  cube-state-engine@1.9.0: {}
 
   cubing@0.56.0:
     dependencies:

--- a/src/entities/replay/model/types.ts
+++ b/src/entities/replay/model/types.ts
@@ -1,12 +1,9 @@
-export interface ReplayMove {
-  m: string
-  t: number
-}
+import type { TimedMove } from 'cube-state-engine'
 
 export interface SolveReplay {
   version: 1
   puzzle: string
   scramble: string
   durationMs: number
-  moves: ReplayMove[]
+  moves: TimedMove[]
 }

--- a/src/features/leaderboards-table/model/useSolveAnalysis.ts
+++ b/src/features/leaderboards-table/model/useSolveAnalysis.ts
@@ -1,15 +1,13 @@
 import { useMemo } from 'react'
 import { tryAnalyzeSolution } from '@/shared/lib/tryAnalyzeSolution'
-import type { ReplayMove } from '@/entities/replay/model/types'
+import type { SolveAnalysis } from 'cube-state-engine'
 import type { SolveServer } from '@/entities/solve/model/types'
 
-type SolveAnalysis = ReturnType<typeof tryAnalyzeSolution>
+const analysisCache = new Map<string, SolveAnalysis | null>()
 
-const analysisCache = new Map<string, SolveAnalysis>()
-
-export function useSolveAnalysis(solve: SolveServer | undefined): SolveAnalysis {
+export function useSolveAnalysis(solve: SolveServer | undefined): SolveAnalysis | null {
   return useMemo(() => {
-    const moves = solve?.replay?.moves as ReplayMove[] | undefined
+    const moves = solve?.replay?.moves
     if (!solve || !moves?.length) return null
 
     const cached = analysisCache.get(solve._id)

--- a/src/features/leaderboards-table/ui/LeaderboardTableRow.tsx
+++ b/src/features/leaderboards-table/ui/LeaderboardTableRow.tsx
@@ -13,7 +13,6 @@ import { TimeDisplay } from '@/features/leaderboards-table/ui/TimeDisplay'
 import { UserCell } from '@/features/leaderboards-table/ui/UserCell'
 import { GRID } from '@/features/leaderboards-table/ui/LeaderboardTable'
 import { SolveServer } from '@/entities/solve/model/types'
-import type { ReplayMove } from '@/entities/replay/model/types'
 import { useLocale, useTranslations } from 'next-intl'
 import { cn } from '@/shared/lib/utils'
 
@@ -49,7 +48,7 @@ export default function LeaderboardTableRow({ solve, index }: LeaderboardTableRo
           : 'border-l-transparent'
   const hasReplay = Boolean(solve.replay?.moves?.length)
   const tps = analysis?.tps != null ? formatTps(analysis.tps) : null
-  const moveCount = analysis ? (analysis.moves as ReplayMove[]).length : null
+  const moveCount = analysis ? analysis.moves.length : null
 
   return (
     <motion.div

--- a/src/features/manage-solves/ui/SolveBreakdown.tsx
+++ b/src/features/manage-solves/ui/SolveBreakdown.tsx
@@ -1,9 +1,9 @@
 import formatTime from '@/shared/lib/formatTime'
 import { buildBarSegments, buildPhases } from '@/shared/lib/timer/solveAnalysis'
-import { tryAnalyzeSolution } from '@/shared/lib/tryAnalyzeSolution'
+import type { SolveAnalysis } from 'cube-state-engine'
 
 interface SolveBreakdownProps {
-  analysis: ReturnType<typeof tryAnalyzeSolution>
+  analysis: SolveAnalysis | null
   totalMs: number
 }
 

--- a/src/features/manage-solves/ui/SolveDetails.tsx
+++ b/src/features/manage-solves/ui/SolveDetails.tsx
@@ -18,7 +18,6 @@ import { formatTps } from '@/shared/lib/formatTps'
 import { SolveBreakdown } from '@/features/manage-solves/ui/SolveBreakdown'
 import { cn } from '@/shared/lib/utils'
 import { RotateCw, Zap, Layers } from 'lucide-react'
-import type { ReplayMove } from '@/entities/replay/model/types'
 
 export default function SolveDetails() {
   const t = useTranslations('Index')
@@ -35,7 +34,7 @@ export default function SolveDetails() {
   const [visualization, setVisualization] = useState<'2D' | '3D'>('2D')
 
   const analysis = solve?.replay?.moves?.length ? tryAnalyzeSolution(solve.replay.moves) : null
-  const moveCount = analysis ? (analysis.moves as ReplayMove[]).length : null
+  const moveCount = analysis ? analysis.moves.length : null
   const tps = analysis?.tps != null ? formatTps(analysis.tps) : null
 
   const solveDate = dayjs(solve?.endTime || 0).locale(locale)

--- a/src/features/replay-solve-details/model/useReplaySolveDetails.ts
+++ b/src/features/replay-solve-details/model/useReplaySolveDetails.ts
@@ -3,10 +3,11 @@ import { tryAnalyzeSolution } from '@/shared/lib/tryAnalyzeSolution'
 import { buildPhases } from '@/shared/lib/timer/solveAnalysis'
 import { formatTps } from '@/shared/lib/formatTps'
 import formatTime from '@/shared/lib/formatTime'
-import type { SolveReplay, ReplayMove } from '@/entities/replay/model/types'
+import type { SolveAnalysis } from 'cube-state-engine'
+import type { SolveReplay } from '@/entities/replay/model/types'
 import type { ReplayMarker } from '@/features/solve-replay/ui/RealtimeReplayPlayer'
 
-function phaseMarkers(analysis: ReturnType<typeof tryAnalyzeSolution>): ReplayMarker[] {
+function phaseMarkers(analysis: SolveAnalysis | null): ReplayMarker[] {
   const phases = buildPhases(analysis)
   if (!phases) return []
 
@@ -40,10 +41,8 @@ export function useReplaySolveDetails() {
   const analysis = hasReplay ? tryAnalyzeSolution(replay!.moves) : null
 
   const tps = analysis?.tps != null ? formatTps(analysis.tps) : null
-  const moveCount = analysis ? (analysis.moves as ReplayMove[]).length : null
-  const simplifiedSolution = analysis
-    ? (analysis.moves as ReplayMove[]).map((x) => x.m).join(' ')
-    : (metadata?.solution ?? null)
+  const moveCount = analysis ? analysis.moves.length : null
+  const simplifiedSolution = analysis ? analysis.moves.map((x) => x.m).join(' ') : (metadata?.solution ?? null)
   const markers = phaseMarkers(analysis)
 
   return { metadata, replay, hasReplay, analysis, tps, moveCount, simplifiedSolution, markers }

--- a/src/features/smart-cube-stats/lib/computeSmartCubeStats.ts
+++ b/src/features/smart-cube-stats/lib/computeSmartCubeStats.ts
@@ -1,5 +1,5 @@
 import type { Solve } from '@/entities/solve/model/types'
-import type { ReplayMove } from '@/entities/replay/model/types'
+import type { TimedMove } from 'cube-state-engine'
 import { tryAnalyzeSolution } from '@/shared/lib/tryAnalyzeSolution'
 import { buildPhases, type PhaseInfo } from '@/shared/lib/timer/solveAnalysis'
 
@@ -66,7 +66,7 @@ const EMPTY_STATS: SmartCubeStats = {
 }
 
 /** Sum and count of inter-move gaps longer than the pause threshold. */
-function pauseStats(moves: ReplayMove[]): { ms: number; count: number } {
+function pauseStats(moves: TimedMove[]): { ms: number; count: number } {
   let ms = 0
   let count = 0
   for (let i = 1; i < moves.length; i++) {
@@ -135,7 +135,7 @@ export function computeSmartCubeStats(solves: Solve[] | undefined): SmartCubeSta
       method,
       total: analysis.total ?? solve.time,
       tps: analysis.tps ?? 0,
-      moveCount: (analysis.moves as ReplayMove[] | undefined)?.length ?? moves.length,
+      moveCount: analysis.moves.length,
       pausedMs: pauses.ms,
       pauseCount: pauses.count,
       phases: buildPhases(analysis)

--- a/src/features/timer/model/useSaveVirtualSolve.ts
+++ b/src/features/timer/model/useSaveVirtualSolve.ts
@@ -1,18 +1,17 @@
 import { useCallback } from 'react'
-import { CubeEngine } from 'cube-state-engine'
+import { CubeEngine, type TimedMove } from 'cube-state-engine'
 import { useTimerStore } from '@/shared/model/timer/useTimerStore'
 import { useSettingsStore } from '@/shared/model/settings/useSettingsStore'
 import { sendSolveToServer } from '@/shared/lib/actions'
 import { cubesDB } from '@/entities/cube/api/indexdb'
 import genId from '@/shared/lib/genId'
 import { Solve } from '@/entities/solve/model/types'
-import { ReplayMove } from '@/entities/replay/model/types'
 
 interface SavePayload {
   timeMs: number
   scramble: string | null
   dnf: boolean
-  replayMoves?: ReplayMove[]
+  replayMoves?: TimedMove[]
   smart?: boolean
 }
 

--- a/src/features/timer/model/useSolveReplayRecorder.ts
+++ b/src/features/timer/model/useSolveReplayRecorder.ts
@@ -1,9 +1,9 @@
 import { useCallback, useRef } from 'react'
-import type { ReplayMove } from '@/entities/replay/model/types'
+import type { TimedMove } from 'cube-state-engine'
 
 export function useSolveReplayRecorder() {
   const startRef = useRef<number | null>(null)
-  const movesRef = useRef<ReplayMove[]>([])
+  const movesRef = useRef<TimedMove[]>([])
 
   const record = useCallback((move: string, opts?: { t?: number }) => {
     const now = performance.now()
@@ -17,7 +17,7 @@ export function useSolveReplayRecorder() {
     movesRef.current = []
   }, [])
 
-  const getMoves = useCallback((): ReplayMove[] => movesRef.current.slice(), [])
+  const getMoves = useCallback((): TimedMove[] => movesRef.current.slice(), [])
 
   return { record, reset, getMoves }
 }

--- a/src/features/timer/model/useSolveSession.ts
+++ b/src/features/timer/model/useSolveSession.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { TwistyPlayer } from 'cubing/twisty'
-import { CubeEngine, simplifyMoves } from 'cube-state-engine'
+import { CubeEngine, simplifyMoves, type CubeSize } from 'cube-state-engine'
 import { useSolveClock } from '@/features/timer/model/useSolveClock'
 import { useSolveReplayRecorder } from '@/features/timer/model/useSolveReplayRecorder'
 import { useSaveVirtualSolve } from '@/features/timer/model/useSaveVirtualSolve'
@@ -37,7 +37,7 @@ interface UseSolveSessionArgs {
   player: TwistyPlayer | null
   engine: CubeEngine | null | undefined
   scramble: string | null
-  cubeSize: number
+  cubeSize: CubeSize
   smart: boolean
   // `auto`: engine arrives scrambled, session starts `armed` (keyboard).
   // `manual`: engine starts solved, user reaches the scrambled state to arm (smart).
@@ -45,7 +45,6 @@ interface UseSolveSessionArgs {
   onAdvanceScramble: () => void
   recreatePlayer: () => void
   inspection?: InspectionConfig
-  goalPredicate?: (engine: CubeEngine) => boolean
 }
 
 export function useSolveSession({
@@ -57,10 +56,8 @@ export function useSolveSession({
   scrambleMode,
   onAdvanceScramble,
   recreatePlayer,
-  inspection = { enabled: false, durationMs: DEFAULT_INSPECTION_MS },
-  goalPredicate
+  inspection = { enabled: false, durationMs: DEFAULT_INSPECTION_MS }
 }: UseSolveSessionArgs) {
-  const isGoalMet = goalPredicate ?? ((eng: CubeEngine) => eng.isSolved())
   const inspectionEnabled = inspection.enabled
   const inspectionDuration = inspection.durationMs || DEFAULT_INSPECTION_MS
   const armedPhase: SolvePhase = inspectionEnabled ? 'inspecting' : 'armed'
@@ -102,8 +99,7 @@ export function useSolveSession({
     recreatePlayer,
     inspectionEnabled,
     inspectionDuration,
-    armedPhase,
-    isGoalMet
+    armedPhase
   })
   latest.current = {
     player,
@@ -118,8 +114,7 @@ export function useSolveSession({
     recreatePlayer,
     inspectionEnabled,
     inspectionDuration,
-    armedPhase,
-    isGoalMet
+    armedPhase
   }
 
   const setPhase = useCallback((next: SolvePhase) => {
@@ -149,8 +144,7 @@ export function useSolveSession({
 
       if (!dnf) {
         try {
-          const simplified = simplifyMoves(engine?.getMoves(false) ?? []) as string[]
-          const moveCount = simplified.length
+          const moveCount = simplifyMoves(engine?.getMoves(false) ?? []).length
           const tps = finalTime > 0 ? moveCount / (finalTime / 1000) : 0
           setSolveStats(moveCount > 0 ? { moveCount, tps } : null)
         } catch {
@@ -208,7 +202,7 @@ export function useSolveSession({
 
   const processMove = useCallback(
     (move: string, opts?: { isRotation?: boolean }) => {
-      const { player, engine, clock, recorder, isGoalMet } = latest.current
+      const { player, engine, clock, recorder } = latest.current
       if (!player || !engine) return
       if (Date.now() < postSolveLockRef.current) return
 
@@ -257,11 +251,11 @@ export function useSolveSession({
         setPhase('solving')
       }
 
-      // Only test the terminal goal once actually solving, so a goal already
-      // satisfied at the armed/case state cannot finalize with ~0 time.
+      // Only test for solved once actually solving, so a cube already solved at
+      // the armed state cannot finalize with ~0 time.
       if (phaseRef.current === 'solving') {
         try {
-          if (isGoalMet(engine)) finalize()
+          if (engine.isSolved()) finalize()
         } catch {}
       }
     },

--- a/src/features/timer/model/useVirtualCube.ts
+++ b/src/features/timer/model/useVirtualCube.ts
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { TwistyPlayer } from 'cubing/twisty'
-import { CubeEngine } from 'cube-state-engine'
+import { CubeEngine, type CubeSize } from 'cube-state-engine'
 import { disposeTwistyPlayer } from '@/shared/lib/twisty/disposeTwistyPlayer'
 
 interface UseVirtualCubeArgs {
-  cubeSize: number
+  cubeSize: CubeSize
   scramble: string | null
   seed?: boolean
   tempoScale?: number
@@ -23,7 +23,7 @@ interface PlayerOptions {
   cameraDistance?: number
 }
 
-const buildPlayer = (cubeSize: number, scramble: string | null, opts?: PlayerOptions) => {
+const buildPlayer = (cubeSize: CubeSize, scramble: string | null, opts?: PlayerOptions) => {
   const player = new TwistyPlayer({
     puzzle: cubeSize === 2 ? '2x2x2' : '3x3x3',
     controlPanel: 'none',

--- a/src/features/trainer/model/useTrainerSmartSession.ts
+++ b/src/features/trainer/model/useTrainerSmartSession.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { TwistyPlayer } from 'cubing/twisty'
-import { CubeEngine, matchesGoal } from 'cube-state-engine'
+import { CubeEngine, matchesGoal, type GoalName } from 'cube-state-engine'
 import type { SmartCubeConnection } from 'smartcube-web-bluetooth'
 import { useSolveClock } from '@/features/timer/model/useSolveClock'
 import { useSmartCubeMoves } from '@/features/smart-cube/model/useSmartCubeMoves'
@@ -25,7 +25,7 @@ interface UseTrainerSmartSessionArgs {
   engine: CubeEngine | null
   player: TwistyPlayer | null
   connection: SmartCubeConnection | null
-  goal: string
+  goal: GoalName
   targetScramble: string
   targetStateJson: string | null
   onSolved: (timeMs: number, historyFromSolved: string) => void

--- a/src/features/trainer/ui/TrainerSmartTimer.tsx
+++ b/src/features/trainer/ui/TrainerSmartTimer.tsx
@@ -39,7 +39,7 @@ export default function TrainerSmartTimer({ connection }: TrainerSmartTimerProps
   const t = useTranslations('Index.TrainerPage')
   const { set, sessionCases, currentCase, currentAlg, setup } = useTrainerSession()
   const methodSlug = set.slug
-  const goal = (set as { goal?: string }).goal ?? 'full'
+  const goal = set.goal
 
   const advanceCase = useTrainerStore((s) => s.advanceCase)
   const recordSolve = useTrainerStore((s) => s.recordSolve)

--- a/src/shared/const/algorithms-sets.ts
+++ b/src/shared/const/algorithms-sets.ts
@@ -429,7 +429,3 @@ export const ALGORITHM_SETS = [
 ] as const
 
 export type ALGORITHM_SET = (typeof ALGORITHM_SETS)[number]
-
-// Terminal condition used by the smart-cube trainer to auto-detect when a case
-// is solved (see `matchesGoal` in cube-state-engine).
-export type TrainerGoal = 'full' | 'oll' | 'oll+cp' | 'f2l' | 'cross'

--- a/src/shared/lib/timer/solveAnalysis.ts
+++ b/src/shared/lib/timer/solveAnalysis.ts
@@ -1,7 +1,4 @@
-import { tryAnalyzeSolution } from '@/shared/lib/tryAnalyzeSolution'
-
-type Analysis = ReturnType<typeof tryAnalyzeSolution>
-type F2lSlot = { moveIndex: number; at: number; duration: number }
+import type { SolveAnalysis, Stage } from 'cube-state-engine'
 
 export type PhaseInfo = {
   key: string
@@ -19,103 +16,67 @@ export type BarSegment = {
   pct: number
 }
 
-/** Builds the phase breakdown for any supported method, or null if unsupported. */
-export function buildPhases(analysis: Analysis): PhaseInfo[] | null {
-  return buildCfopPhases(analysis) ?? buildRouxPhases(analysis)
+type PhaseSpec = {
+  key: string
+  label: string
+  bgClass: string
+  textClass: string
+  /** Reported as several stages (one per F2L slot), summed into one phase with sub-slots. */
+  grouped?: boolean
 }
 
-/** Returns null if the analysis is not Roux or is missing required phases. */
-export function buildRouxPhases(analysis: Analysis): PhaseInfo[] | null {
-  if (!analysis || analysis.method !== 'Roux') return null
-  const { firstBlock, secondBlock, cmll, lse } = analysis
-  if (!firstBlock || !secondBlock || !cmll || !lse) return null
-
-  return [
-    {
-      key: 'firstBlock',
-      label: 'FB',
-      duration: firstBlock.duration,
-      moveIndex: firstBlock.moveIndex,
-      bgClass: 'bg-sky-500',
-      textClass: 'text-sky-500'
-    },
-    {
-      key: 'secondBlock',
-      label: 'SB',
-      duration: secondBlock.duration,
-      moveIndex: secondBlock.moveIndex,
-      bgClass: 'bg-indigo-500',
-      textClass: 'text-indigo-500'
-    },
-    {
-      key: 'cmll',
-      label: 'CMLL',
-      duration: cmll.duration,
-      moveIndex: cmll.moveIndex,
-      bgClass: 'bg-amber-400',
-      textClass: 'text-amber-400'
-    },
-    {
-      key: 'lse',
-      label: 'LSE',
-      duration: lse.duration,
-      moveIndex: lse.moveIndex,
-      bgClass: 'bg-rose-500',
-      textClass: 'text-rose-500'
-    }
+const METHOD_PHASES: Record<string, PhaseSpec[]> = {
+  CFOP: [
+    { key: 'cross', label: 'Cross', bgClass: 'bg-sky-500', textClass: 'text-sky-500' },
+    { key: 'f2l', label: 'F2L', bgClass: 'bg-emerald-500', textClass: 'text-emerald-500', grouped: true },
+    { key: 'oll', label: 'OLL', bgClass: 'bg-amber-400', textClass: 'text-amber-400' },
+    { key: 'pll', label: 'PLL', bgClass: 'bg-rose-500', textClass: 'text-rose-500' }
+  ],
+  Roux: [
+    { key: 'firstBlock', label: 'FB', bgClass: 'bg-sky-500', textClass: 'text-sky-500' },
+    { key: 'secondBlock', label: 'SB', bgClass: 'bg-indigo-500', textClass: 'text-indigo-500' },
+    { key: 'cmll', label: 'CMLL', bgClass: 'bg-amber-400', textClass: 'text-amber-400' },
+    { key: 'lse', label: 'LSE', bgClass: 'bg-rose-500', textClass: 'text-rose-500' }
   ]
 }
 
-/** Returns null if the analysis is not CFOP or is missing required phases. */
-export function buildCfopPhases(analysis: Analysis): PhaseInfo[] | null {
-  if (!analysis || analysis.method !== 'CFOP') return null
-  const { cross, f2l, oll, pll } = analysis
-  if (!cross || !oll || !pll) return null
+/** Builds the phase breakdown for any supported method, or null if unsupported. */
+export function buildPhases(analysis: SolveAnalysis | null): PhaseInfo[] | null {
+  if (!analysis) return null
+  const specs = METHOD_PHASES[analysis.method]
+  if (!specs) return null
 
-  const f2lSlots = f2l as F2lSlot[]
+  const byKey = new Map<string, Stage[]>()
+  for (const stage of analysis.stages) {
+    const group = byKey.get(stage.key)
+    if (group) group.push(stage)
+    else byKey.set(stage.key, [stage])
+  }
+  if (specs.some((spec) => !spec.grouped && !byKey.has(spec.key))) return null
 
-  return [
-    {
-      key: 'cross',
-      label: 'Cross',
-      duration: cross.duration,
-      moveIndex: cross.moveIndex,
-      bgClass: 'bg-sky-500',
-      textClass: 'text-sky-500'
-    },
-    {
-      key: 'f2l',
-      label: 'F2L',
-      duration: f2lSlots.reduce((sum, s) => sum + s.duration, 0),
-      moveIndex: f2lSlots[f2lSlots.length - 1]?.moveIndex ?? 0,
-      bgClass: 'bg-emerald-500',
-      textClass: 'text-emerald-500',
-      slots: f2lSlots.map((s, i) => ({
-        key: `f2l-${i}`,
+  return specs.map(({ key, label, bgClass, textClass, grouped }) => {
+    const stages = byKey.get(key) ?? []
+    if (!grouped) {
+      const [stage] = stages
+      return { key, label, duration: stage.duration, moveIndex: stage.moveIndex, bgClass, textClass }
+    }
+    return {
+      key,
+      label,
+      duration: stages.reduce((sum, s) => sum + s.duration, 0),
+      moveIndex: stages[stages.length - 1]?.moveIndex ?? 0,
+      bgClass,
+      textClass,
+      slots: stages.map((s, i) => ({
+        key: `${key}-${i}`,
         label: `Slot ${i + 1}`,
         duration: s.duration,
         moveIndex: s.moveIndex,
-        bgClass: 'bg-emerald-500',
-        textClass: 'text-emerald-500'
+        bgClass,
+        textClass
       }))
-    },
-    {
-      key: 'oll',
-      label: 'OLL',
-      duration: oll.duration,
-      moveIndex: oll.moveIndex,
-      bgClass: 'bg-amber-400',
-      textClass: 'text-amber-400'
-    },
-    {
-      key: 'pll',
-      label: 'PLL',
-      duration: pll.duration,
-      moveIndex: pll.moveIndex,
-      bgClass: 'bg-rose-500',
-      textClass: 'text-rose-500'
     }
-  ]
+  })
 }
 
 export function buildBarSegments(phases: PhaseInfo[], totalMs: number): BarSegment[] {

--- a/src/shared/lib/tryAnalyzeSolution.ts
+++ b/src/shared/lib/tryAnalyzeSolution.ts
@@ -1,7 +1,6 @@
-import { analyzeSolution } from 'cube-state-engine'
-import type { ReplayMove } from '@/entities/replay/model/types'
+import { analyzeSolution, type TimedMove } from 'cube-state-engine'
 
-export function tryAnalyzeSolution(moves: ReplayMove[]) {
+export function tryAnalyzeSolution(moves: TimedMove[]) {
   if (!moves.length) return null
   try {
     return analyzeSolution(moves)


### PR DESCRIPTION
**What does this PR do?**
Bumps cube-state-engine to 1.9.0 and adopts the typings it now ships. (https://github.com/bryanlundberg/cube-state-engine/pull/14)

Fixes three type errors the stricter signatures exposed:
- `cubeSize` is now `CubeSize` (`2 | 3`) in `useVirtualCube` and `useSolveSession`.
- `goal` is now `GoalName`. Drops the `(set as { goal?: string })` cast that was
  widening to `string` a value the `as const` array already typed as a literal
  union, which is what let the error through in the first place.

Uses the package's types directly instead of local aliases:
- `ReplayMove` is gone in favour of `TimedMove`, which removes six
  `analysis.moves as ReplayMove[]` casts and two dead imports.
- `ReturnType<typeof tryAnalyzeSolution>` and the local `Analysis` alias become
  `SolveAnalysis | null`.
- Removes the unused `TrainerGoal` type. `set.goal` is still checked against
  `GoalName` where it is passed to the trainer hook.


**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
