### PR TITLE
feat(timer): replace virtual keyboard image with a remappable key editor

### DIFF
--- a/src/features/timer/model/useKeyboardLayoutLabels.ts
+++ b/src/features/timer/model/useKeyboardLayoutLabels.ts
@@ -1,0 +1,42 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+import { FALLBACK_KEY_LABELS } from './virtualKeymap'
+
+type KeyboardLayoutMap = { get: (code: string) => string | undefined }
+type NavigatorWithKeyboard = Navigator & {
+  keyboard?: { getLayoutMap?: () => Promise<KeyboardLayoutMap> }
+}
+
+let cachedLabels: Record<string, string> | null = null
+
+// Labels every physical key with the character it produces on the active layout,
+// so an AZERTY or ES keyboard shows its own legends. Chromium only, hence the fallback.
+export function useKeyboardLayoutLabels() {
+  const [labels, setLabels] = useState(() => cachedLabels ?? FALLBACK_KEY_LABELS)
+
+  useEffect(() => {
+    if (cachedLabels) return
+
+    const keyboard = (navigator as NavigatorWithKeyboard).keyboard
+    if (!keyboard?.getLayoutMap) return
+
+    let cancelled = false
+
+    keyboard
+      .getLayoutMap()
+      .then((layout) => {
+        cachedLabels = Object.fromEntries(
+          Object.entries(FALLBACK_KEY_LABELS).map(([code, fallback]) => [code, layout.get(code) || fallback])
+        )
+        if (!cancelled) setLabels(cachedLabels)
+      })
+      .catch(() => undefined)
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return labels
+}

--- a/src/features/timer/model/useVirtualKeyboardMoves.ts
+++ b/src/features/timer/model/useVirtualKeyboardMoves.ts
@@ -1,5 +1,6 @@
-import { useEffect } from 'react'
-import { VIRTUAL_KEYMAP } from './virtualKeymap'
+import { useEffect, useMemo } from 'react'
+import { resolveVirtualKeymap } from './virtualKeymap'
+import { useVirtualKeymapStore } from './useVirtualKeymapStore'
 
 interface UseVirtualKeyboardMovesArgs {
   is3x3: boolean
@@ -8,14 +9,21 @@ interface UseVirtualKeyboardMovesArgs {
 }
 
 export function useVirtualKeyboardMoves({ is3x3, processMove, cancel }: UseVirtualKeyboardMovesArgs) {
+  const keymap = useVirtualKeymapStore((store) => store.keymap)
+  const isEditorOpen = useVirtualKeymapStore((store) => store.isEditorOpen)
+
+  const resolvedKeymap = useMemo(() => resolveVirtualKeymap(keymap), [keymap])
+
   useEffect(() => {
+    if (isEditorOpen) return
+
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         cancel()
         return
       }
 
-      const mapping = VIRTUAL_KEYMAP[e.key.toLowerCase()]
+      const mapping = e.code ? resolvedKeymap[e.code] : undefined
       if (!mapping) return
       if (mapping.require3x3 && !is3x3) return
 
@@ -24,5 +32,5 @@ export function useVirtualKeyboardMoves({ is3x3, processMove, cancel }: UseVirtu
 
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [is3x3, processMove, cancel])
+  }, [is3x3, processMove, cancel, resolvedKeymap, isEditorOpen])
 }

--- a/src/features/timer/model/useVirtualKeymapStore.ts
+++ b/src/features/timer/model/useVirtualKeymapStore.ts
@@ -1,0 +1,38 @@
+'use client'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+import { DEFAULT_VIRTUAL_KEYMAP } from './virtualKeymap'
+
+interface VirtualKeymapState {
+  // KeyboardEvent.code -> move
+  keymap: Record<string, string>
+  isEditorOpen: boolean
+  setBinding: (code: string, move: string | null) => void
+  resetKeymap: () => void
+  setEditorOpen: (open: boolean) => void
+}
+
+type PersistedVirtualKeymap = Pick<VirtualKeymapState, 'keymap'>
+
+export const useVirtualKeymapStore = create<VirtualKeymapState>()(
+  persist<VirtualKeymapState, [], [], PersistedVirtualKeymap>(
+    (set) => ({
+      keymap: { ...DEFAULT_VIRTUAL_KEYMAP },
+      isEditorOpen: false,
+      setBinding: (code: string, move: string | null) =>
+        set((state) => {
+          const keymap = { ...state.keymap }
+          if (move) keymap[code] = move
+          else delete keymap[code]
+          return { keymap }
+        }),
+      resetKeymap: () => set({ keymap: { ...DEFAULT_VIRTUAL_KEYMAP } }),
+      setEditorOpen: (open: boolean) => set({ isEditorOpen: open })
+    }),
+    {
+      name: 'virtual-keymap',
+      partialize: (state) => ({ keymap: state.keymap })
+    }
+  )
+)

--- a/src/features/timer/model/virtualKeymap.ts
+++ b/src/features/timer/model/virtualKeymap.ts
@@ -4,41 +4,148 @@ export type VirtualKeyMove = {
   require3x3?: boolean
 }
 
-export const VIRTUAL_KEYMAP: Record<string, VirtualKeyMove> = {
-  h: { move: 'F' },
-  g: { move: "F'" },
-  j: { move: 'U' },
-  f: { move: "U'" },
-  i: { move: 'R' },
-  k: { move: "R'" },
-  s: { move: 'D' },
-  l: { move: "D'" },
-  d: { move: 'L' },
-  e: { move: "L'" },
-  w: { move: 'B' },
-  o: { move: "B'" },
+export type VirtualMoveGroup = {
+  id: 'faces' | 'rotations' | 'wide'
+  label: string
+  moves: VirtualKeyMove[]
+}
 
-  y: { move: 'x', isRotation: true },
-  t: { move: 'x', isRotation: true },
-  n: { move: "x'", isRotation: true },
-  b: { move: "x'", isRotation: true },
-  ñ: { move: 'y', isRotation: true },
-  ';': { move: 'y', isRotation: true },
-  a: { move: "y'", isRotation: true },
-  p: { move: 'z', isRotation: true },
-  q: { move: "z'", isRotation: true },
+export const VIRTUAL_MOVE_GROUPS: VirtualMoveGroup[] = [
+  {
+    id: 'faces',
+    label: 'Faces',
+    moves: [
+      { move: 'F' },
+      { move: "F'" },
+      { move: 'U' },
+      { move: "U'" },
+      { move: 'R' },
+      { move: "R'" },
+      { move: 'D' },
+      { move: "D'" },
+      { move: 'L' },
+      { move: "L'" },
+      { move: 'B' },
+      { move: "B'" }
+    ]
+  },
+  {
+    id: 'rotations',
+    label: 'Rotations',
+    moves: [
+      { move: 'x', isRotation: true },
+      { move: "x'", isRotation: true },
+      { move: 'y', isRotation: true },
+      { move: "y'", isRotation: true },
+      { move: 'z', isRotation: true },
+      { move: "z'", isRotation: true }
+    ]
+  },
+  {
+    id: 'wide',
+    label: 'Wide & slice',
+    moves: [
+      { move: 'Uw', require3x3: true },
+      { move: "Uw'", require3x3: true },
+      { move: 'Dw', require3x3: true },
+      { move: "Dw'", require3x3: true },
+      { move: 'Rw', require3x3: true },
+      { move: "Rw'", require3x3: true },
+      { move: 'Lw', require3x3: true },
+      { move: "Lw'", require3x3: true },
+      { move: 'M', require3x3: true },
+      { move: "M'", require3x3: true }
+    ]
+  }
+]
 
-  ',': { move: 'Uw', require3x3: true },
-  c: { move: "Uw'", require3x3: true },
-  z: { move: 'Dw', require3x3: true },
-  '-': { move: "Dw'", require3x3: true },
-  '/': { move: "Dw'", require3x3: true },
-  u: { move: 'Rw', require3x3: true },
-  m: { move: "Rw'", require3x3: true },
-  v: { move: 'Lw', require3x3: true },
-  r: { move: "Lw'", require3x3: true },
-  '.': { move: "M'", require3x3: true },
-  x: { move: "M'", require3x3: true },
-  '5': { move: 'M', require3x3: true },
-  '6': { move: 'M', require3x3: true }
+export const VIRTUAL_MOVES: Record<string, VirtualKeyMove> = Object.fromEntries(
+  VIRTUAL_MOVE_GROUPS.flatMap((group) => group.moves.map((move) => [move.move, move]))
+)
+
+// KeyboardEvent.code values: physical positions, identical on any keyboard layout
+export const VIRTUAL_KEYBOARD_ROWS: string[][] = [
+  [
+    'Digit1',
+    'Digit2',
+    'Digit3',
+    'Digit4',
+    'Digit5',
+    'Digit6',
+    'Digit7',
+    'Digit8',
+    'Digit9',
+    'Digit0',
+    'Minus',
+    'Equal'
+  ],
+  ['KeyQ', 'KeyW', 'KeyE', 'KeyR', 'KeyT', 'KeyY', 'KeyU', 'KeyI', 'KeyO', 'KeyP'],
+  ['KeyA', 'KeyS', 'KeyD', 'KeyF', 'KeyG', 'KeyH', 'KeyJ', 'KeyK', 'KeyL', 'Semicolon', 'Quote'],
+  ['KeyZ', 'KeyX', 'KeyC', 'KeyV', 'KeyB', 'KeyN', 'KeyM', 'Comma', 'Period', 'Slash']
+]
+
+export const DEFAULT_VIRTUAL_KEYMAP: Record<string, string> = {
+  KeyH: 'F',
+  KeyG: "F'",
+  KeyJ: 'U',
+  KeyF: "U'",
+  KeyI: 'R',
+  KeyK: "R'",
+  KeyS: 'D',
+  KeyL: "D'",
+  KeyD: 'L',
+  KeyE: "L'",
+  KeyW: 'B',
+  KeyO: "B'",
+
+  KeyY: 'x',
+  KeyT: 'x',
+  KeyN: "x'",
+  KeyB: "x'",
+  Semicolon: 'y',
+  KeyA: "y'",
+  KeyP: 'z',
+  KeyQ: "z'",
+
+  Comma: 'Uw',
+  KeyC: "Uw'",
+  KeyZ: 'Dw',
+  Slash: "Dw'",
+  KeyU: 'Rw',
+  KeyM: "Rw'",
+  KeyV: 'Lw',
+  KeyR: "Lw'",
+  Period: "M'",
+  KeyX: "M'",
+  Digit5: 'M',
+  Digit6: 'M'
+}
+
+const PUNCTUATION_LABELS: Record<string, string> = {
+  Minus: '-',
+  Equal: '=',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/'
+}
+
+// US legends, used until the browser reports the active layout
+export const FALLBACK_KEY_LABELS: Record<string, string> = Object.fromEntries(
+  VIRTUAL_KEYBOARD_ROWS.flat().map((code) => [
+    code,
+    PUNCTUATION_LABELS[code] ?? code.replace(/^(Key|Digit)/, '').toLowerCase()
+  ])
+)
+
+export function resolveVirtualKeymap(keymap: Record<string, string>): Record<string, VirtualKeyMove> {
+  const resolved: Record<string, VirtualKeyMove> = {}
+
+  for (const [code, move] of Object.entries(keymap)) {
+    const definition = VIRTUAL_MOVES[move]
+    if (definition) resolved[code] = definition
+  }
+
+  return resolved
 }

--- a/src/features/timer/ui/ScrambleZone.tsx
+++ b/src/features/timer/ui/ScrambleZone.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react'
 import { useTranslations } from 'next-intl'
-import Image from 'next/image'
 import { AnimatePresence, motion } from 'motion/react'
 import { Keyboard, Lightbulb } from 'lucide-react'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
@@ -27,6 +26,7 @@ import { Layers } from '@/shared/types/enums'
 import { CrossSolution } from '@/shared/types/types'
 
 import DrawerHintPanel from '@/features/timer/ui/drawer-hint-panel'
+import VirtualKeymapEditor from '@/features/timer/ui/VirtualKeymapEditor'
 import FocusModeToggle from '@/features/focus-mode/ui/FocusModeToggle'
 import { useFocusModeStore } from '@/features/focus-mode/model/useFocusModeStore'
 import { TimerMode } from '@/features/timer/model/enums'
@@ -204,19 +204,17 @@ export function ScrambleZone() {
                     </Button>
                   </DialogTrigger>
                 </TooltipTrigger>
-                <DialogContent className="sm:max-w-xl">
+                <DialogContent
+                  className="p-4 sm:max-w-3xl sm:p-6"
+                  showCloseButton
+                  onPointerDownOutside={(e) => e.preventDefault()}
+                  onInteractOutside={(e) => e.preventDefault()}
+                >
                   <DialogHeader>
                     <DialogTitle>Keyboard controls</DialogTitle>
+                    <DialogDescription>Click any key to change the move it triggers.</DialogDescription>
                   </DialogHeader>
-                  <div className="w-full flex items-center justify-center p-2">
-                    <Image
-                      src="/utils/keyboard.jpg"
-                      alt="keyboard controls"
-                      width={600}
-                      height={400}
-                      className="w-full h-auto"
-                    />
-                  </div>
+                  <VirtualKeymapEditor />
                 </DialogContent>
                 <TooltipContent>
                   <p>Keyboard</p>

--- a/src/features/timer/ui/VirtualKeymapEditor.tsx
+++ b/src/features/timer/ui/VirtualKeymapEditor.tsx
@@ -1,0 +1,71 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { RotateCcw } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import { useVirtualKeymapStore } from '@/features/timer/model/useVirtualKeymapStore'
+import { useKeyboardLayoutLabels } from '@/features/timer/model/useKeyboardLayoutLabels'
+import { VIRTUAL_KEYBOARD_ROWS } from '@/features/timer/model/virtualKeymap'
+import VirtualKeymapKey from '@/features/timer/ui/VirtualKeymapKey'
+
+const ROW_PADDING = ['0', 'calc(var(--key-w) * 0.25)', 'calc(var(--key-w) * 0.6)', 'calc(var(--key-w) * 0.9)']
+
+export default function VirtualKeymapEditor() {
+  const keymap = useVirtualKeymapStore((store) => store.keymap)
+  const setBinding = useVirtualKeymapStore((store) => store.setBinding)
+  const resetKeymap = useVirtualKeymapStore((store) => store.resetKeymap)
+  const setEditorOpen = useVirtualKeymapStore((store) => store.setEditorOpen)
+
+  const layoutLabels = useKeyboardLayoutLabels()
+  const [pressedCode, setPressedCode] = useState<string | null>(null)
+
+  useEffect(() => {
+    setEditorOpen(true)
+    return () => setEditorOpen(false)
+  }, [setEditorOpen])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => setPressedCode(e.code)
+    const clearPressed = () => setPressedCode(null)
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', clearPressed)
+    window.addEventListener('blur', clearPressed)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', clearPressed)
+      window.removeEventListener('blur', clearPressed)
+    }
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="@container w-full">
+        <div className="mx-auto flex w-fit flex-col gap-(--key-gap) [--key-gap:min(0.375rem,1cqw)] [--key-h:min(3rem,8.4cqw)] [--key-w:min(2.75rem,7.3cqw)]">
+          {VIRTUAL_KEYBOARD_ROWS.map((row, rowIndex) => (
+            <div key={rowIndex} className="flex gap-(--key-gap)" style={{ paddingLeft: ROW_PADDING[rowIndex] }}>
+              {row.map((code) => (
+                <VirtualKeymapKey
+                  key={code}
+                  code={code}
+                  label={layoutLabels[code] ?? code}
+                  move={keymap[code]}
+                  isPressed={pressedCode === code}
+                  onSelect={setBinding}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Button variant="outline" size="sm" onClick={resetKeymap}>
+          <RotateCcw />
+          Restore defaults
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/timer/ui/VirtualKeymapKey.tsx
+++ b/src/features/timer/ui/VirtualKeymapKey.tsx
@@ -1,0 +1,89 @@
+'use client'
+import { Fragment, memo } from 'react'
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+
+import { cn } from '@/shared/lib/utils'
+import { VIRTUAL_MOVE_GROUPS, VIRTUAL_MOVES } from '@/features/timer/model/virtualKeymap'
+
+type VirtualKeymapKeyProps = {
+  code: string
+  label: string
+  move?: string
+  isPressed: boolean
+  onSelect: (code: string, move: string | null) => void
+}
+
+function VirtualKeymapKey({ code, label, move, isPressed, onSelect }: VirtualKeymapKeyProps) {
+  const definition = move ? VIRTUAL_MOVES[move] : undefined
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={definition ? `${label.toUpperCase()}: ${definition.move}` : label.toUpperCase()}
+          className={cn(
+            'relative flex h-(--key-h) w-(--key-w) cursor-pointer flex-col items-center justify-center gap-0.5 rounded-md border transition-colors',
+            'focus-visible:ring-ring/50 outline-none focus-visible:ring-2',
+            definition
+              ? 'border-primary/40 bg-primary/10 text-foreground hover:bg-primary/20'
+              : 'border-border/60 bg-muted/30 text-muted-foreground hover:bg-muted/60',
+            isPressed && 'ring-primary/60 ring-2'
+          )}
+        >
+          <span className="text-[length:min(0.625rem,2.2cqw)] leading-none uppercase opacity-60">{label}</span>
+          <span className="text-[length:min(0.875rem,3.1cqw)] leading-none font-semibold">
+            {definition ? definition.move : '·'}
+          </span>
+          {definition?.require3x3 && (
+            <span className="bg-primary/70 absolute top-[8%] right-[8%] size-[min(0.375rem,1.2cqw)] rounded-full" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="center" className="w-60">
+        {VIRTUAL_MOVE_GROUPS.map((group, groupIndex) => (
+          <Fragment key={group.id}>
+            {groupIndex > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+            <div className="grid grid-cols-4 gap-1">
+              {group.moves.map((option) => (
+                <DropdownMenuItem
+                  key={option.move}
+                  highlight="rounded"
+                  onSelect={() => onSelect(code, option.move)}
+                  className={cn(
+                    'justify-center px-1 py-1.5 text-xs font-medium',
+                    move === option.move && 'bg-primary/15 text-foreground'
+                  )}
+                >
+                  {option.move}
+                </DropdownMenuItem>
+              ))}
+            </div>
+          </Fragment>
+        ))}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          highlight="rounded"
+          disabled={!move}
+          onSelect={() => onSelect(code, null)}
+        >
+          Clear key
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export default memo(VirtualKeymapKey)

--- a/src/features/timer/ui/VirtualKeymapKey.tsx
+++ b/src/features/timer/ui/VirtualKeymapKey.tsx
@@ -43,9 +43,6 @@ function VirtualKeymapKey({ code, label, move, isPressed, onSelect }: VirtualKey
           <span className="text-[length:min(0.875rem,3.1cqw)] leading-none font-semibold">
             {definition ? definition.move : '·'}
           </span>
-          {definition?.require3x3 && (
-            <span className="bg-primary/70 absolute top-[8%] right-[8%] size-[min(0.375rem,1.2cqw)] rounded-full" />
-          )}
         </button>
       </DropdownMenuTrigger>
 


### PR DESCRIPTION
**What does this PR do?**
Replaces the static controls image in the virtual mode dialog with an interactive
on-screen keyboard that doubles as the keymap configuration.

- Click any key to bind a move (faces, rotations, wide and slice) or clear it.
- "Restore defaults" resets the whole map.
- Bindings persist in localStorage (`virtual-keymap`).

**Related Issue(s)**
#620 

**Screenshots or GIFs (if applicable)**
<img width="2551" height="1222" alt="image" src="https://github.com/user-attachments/assets/cbe3dc0d-d74d-4741-bef2-58c203764728" />

**By submitting this PR, I confirm that:**
- [x] I have reviewed my code and believe it is ready for merging.
- [x] I understand that this PR may be subject to review and changes.
- [x] I agree to abide by the code of conduct and contributing guidelines of this project.
